### PR TITLE
Increase showcase bundle budget

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -64,7 +64,7 @@
                 {
                   "type": "initial",
                   "maximumWarning": "500kb",
-                  "maximumError": "1mb"
+                  "maximumError": "1.5mb"
                 },
                 {
                   "type": "anyComponentStyle",


### PR DESCRIPTION
Increased initial budget error threshold to 1.5mb so the build will succeed.
We should review the budget again after we implement lazy-loading.
