### PR TITLE
Configurable chart size

### DIFF
--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.css
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.css
@@ -1,6 +1,12 @@
-.empty-message {
+.chart-container {
   position: relative;
-  top: -300px;
-  left: 400px;
+}
+
+.empty-message {
+  width: 100%;
+  height: 100%;
   z-index: 10;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.html
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.html
@@ -1,4 +1,6 @@
-<div class="chart-container" style="position: relative; width: 60vw">
-  <canvas width="100%" baseChart [type]="type ?? defaultType" [datasets]="datasets ?? defaultDatasets" [options]="options ?? defaultOptions"></canvas>
-  <div *ngIf="!datasets || datasets.length < 1" class="empty-message">No data layers are selected</div>
+<div class="chart-container" [style.width]="width" [style.height]="height">
+  <canvas *ngIf="datasets && datasets.length > 0; else empty" width="100%" baseChart [type]="type ?? defaultType" [datasets]="datasets" [options]="options ?? defaultOptions"></canvas>
+  <ng-template #empty>
+    <div class="empty-message"><div class="empty-message-content">No data layers are selected</div></div>
+  </ng-template>
 </div>

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.ts
@@ -16,16 +16,21 @@ export class FhirChartComponent implements OnInit {
   defaultType: ChartConfiguration['type'] = 'line';
   @Input() type: ChartConfiguration['type'] | null = this.defaultType;
 
-  defaultDatasets: ChartConfiguration['data']['datasets'] = [];
-  @Input() datasets: ChartConfiguration['data']['datasets'] | null = this.defaultDatasets;
+  @Input() datasets: ChartConfiguration['data']['datasets'] | null = [];
 
   defaultOptions: ChartConfiguration['options'] = {};
   @Input() options: ChartConfiguration['options'] | null = this.defaultOptions;
+
+  @Input() width: string = "600px";
+  @Input() height: string = "300px";
 
   constructor(private configService: FhirChartConfigurationService) {}
 
   ngOnInit(): void {
     Chart.register(annotationPlugin, zoomPlugin);
+
+    // To responsively resize the chart based on its container size, we must set maintainAspectRatio = false
+    Chart.defaults.maintainAspectRatio = false;
 
     Chart.defaults.plugins.zoom = merge(Chart.defaults.plugins.zoom, {
       pan: {

--- a/projects/showcase/src/app/app.component.html
+++ b/projects/showcase/src/app/app.component.html
@@ -25,7 +25,7 @@
           <mat-expansion-panel-header>
             <mat-panel-title> Chart </mat-panel-title>
           </mat-expansion-panel-header>
-          <fhir-chart></fhir-chart>
+          <fhir-chart width="calc(65vw - 48px)" height="500px"></fhir-chart>
         </mat-expansion-panel>
         <mat-expansion-panel expanded="true">
           <mat-expansion-panel-header>


### PR DESCRIPTION
- Added `width` and `height` inputs to fhir-chart component
- Fixed centering of the empty chart message
- Disabled the chart.js `maintainAspectRatio` option
- Updated showcase app set the width/height