### PR TITLE
Exclude tests and angular files from test coverage

### DIFF
--- a/.github/workflows/build-test.js.yml
+++ b/.github/workflows/build-test.js.yml
@@ -47,5 +47,5 @@ jobs:
           -Dsonar.projectKey=elimuinformatics_charts-on-fhir
           -Dsonar.organization=elimuinformatics-1
           -Dsonar.javascript.lcov.reportPaths=coverage/**/lcov.info
-          -Dsonar.exclusions=**/*.spec.ts,**/test.ts,**/main.ts,**/polyfills.ts,**/*.module.ts,**/environment*.ts,**/*.js
+          -Dsonar.coverage.exclusions=**/*.spec.ts,**/test.ts,**/main.ts,**/polyfills.ts,**/*.module.ts,**/environment*.ts,**/*.js
           -Dsonar.test.inclusions=**/*.spec.ts,**/test.ts

--- a/.github/workflows/build-test.js.yml
+++ b/.github/workflows/build-test.js.yml
@@ -47,3 +47,5 @@ jobs:
           -Dsonar.projectKey=elimuinformatics_charts-on-fhir
           -Dsonar.organization=elimuinformatics-1
           -Dsonar.javascript.lcov.reportPaths=coverage/**/lcov.info
+          -Dsonar.exclusions=**/*.spec.ts,**/test.ts,**/main.ts,**/polyfills.ts,**/*.module.ts,**/environment*.ts,**/*.js
+          -Dsonar.test.inclusions=**/*.spec.ts,**/test.ts


### PR DESCRIPTION
## Overview

Added `sonar.coverage.exclusions` and `sonar.test.inclusions` parameters so SonarCloud scan will calculate test coverage correctly.

## How it was tested

I can't find a way to view the sonar code coverage report for this PR. I will test it by merging the PR so the updated workflow runs on main.

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)
