### PR TITLE
use sidenav autosize

### DIFF
--- a/projects/showcase/src/app/app.component.html
+++ b/projects/showcase/src/app/app.component.html
@@ -1,5 +1,5 @@
 <data-layer-toolbar [active]="sidenavPanel" (change)="onToolbarChange(sidenav, $event)"></data-layer-toolbar>
-<mat-sidenav-container>
+<mat-sidenav-container autosize="true">
   <mat-sidenav mode="side" #sidenav opened>
     <div class="layout-sidebar">
       <div class="layout-sidebar-content">

--- a/projects/showcase/src/app/app.component.ts
+++ b/projects/showcase/src/app/app.component.ts
@@ -16,9 +16,7 @@ export class AppComponent implements OnInit {
   onToolbarChange(sidenav: MatSidenav, panel: string | null) {
     if (panel) {
       this.sidenavPanel = panel;
-      // close and then asynchronously re-open sidenav to trigger a resize
-      sidenav.close();
-      setTimeout(() => sidenav.open());
+      sidenav.open();
     } else {
       sidenav.close();
     }


### PR DESCRIPTION
## Overview

Use sidenav's autosize property instead of close and re-open, which was causing animation glitches.

## How it was tested

Ran showcase app, added layers with long names, switched sidenav panels back and forth to check resizing.

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)
