### PR TITLE
Fix event names

### DIFF
--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-list/data-layer-list/data-layer-list.component.html
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-list/data-layer-list/data-layer-list.component.html
@@ -31,7 +31,7 @@
           {{ layer.name }}
         </mat-panel-title>
       </mat-expansion-panel-header>
-      <data-layer-options [layer]="layer" (change)="onLayerChange($event)"></data-layer-options>
+      <data-layer-options [layer]="layer" (layerChange)="onLayerChange($event)"></data-layer-options>
       <mat-action-row>
         <button mat-mini-fab color="primary" (click)="onLayerRemove(layer)" title="Remove this layer"><mat-icon fontIcon="delete"></mat-icon></button>
       </mat-action-row>

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-list/data-layer-options/data-layer-options.component.html
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-list/data-layer-options/data-layer-options.component.html
@@ -1,1 +1,1 @@
-<dataset-list [datasets]="layer?.datasets" (change)="onDatasetsChange($event)"></dataset-list>
+<dataset-list [datasets]="layer?.datasets" (datasetsChange)="onDatasetsChange($event)"></dataset-list>

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-list/data-layer-options/data-layer-options.component.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-list/data-layer-options/data-layer-options.component.ts
@@ -9,11 +9,11 @@ import { Dataset, ManagedDataLayer } from '../../data-layer/data-layer';
 })
 export class DataLayerOptionsComponent {
   @Input() layer?: ManagedDataLayer;
-  @Output() change = new EventEmitter<ManagedDataLayer>();
+  @Output() layerChange = new EventEmitter<ManagedDataLayer>();
 
   onDatasetsChange(datasets: Dataset[]) {
     if (this.layer) {
-      this.change.emit(
+      this.layerChange.emit(
         produce(this.layer, (draft) => {
           draft.datasets = castDraft(datasets);
           draft.enabled = datasets.some((dataset) => !dataset.hidden);

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-list/dataset-list/dataset-list.component.html
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-list/dataset-list/dataset-list.component.html
@@ -14,7 +14,7 @@
         </mat-panel-title>
         <mat-panel-description> {{ dataset.data.length }} observations </mat-panel-description>
       </mat-expansion-panel-header>
-      <dataset-options [dataset]="dataset" (change)="this.onDatasetOptionsChange(dataset, $event)"></dataset-options>
+      <dataset-options [dataset]="dataset" (datasetChange)="this.onDatasetOptionsChange(dataset, $event)"></dataset-options>
     </mat-expansion-panel>
   </mat-accordion>
 </div>

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-list/dataset-list/dataset-list.component.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-list/dataset-list/dataset-list.component.ts
@@ -15,12 +15,12 @@ export class DatasetListComponent {
     this._datasets = datasets;
     this.datasetsReversed = datasets?.slice().reverse();
   }
-  @Output() change = new EventEmitter<Dataset[]>();
+  @Output() datasetsChange = new EventEmitter<Dataset[]>();
 
   onCheckboxChange(dataset: Dataset, event: MatCheckboxChange) {
     if (this._datasets) {
       const index = this._datasets.indexOf(dataset);
-      this.change.emit(
+      this.datasetsChange.emit(
         produce(this._datasets, (draft) => {
           draft[index].hidden = !event.checked;
         })
@@ -31,7 +31,7 @@ export class DatasetListComponent {
   onDatasetOptionsChange(oldDataset: Dataset, newDataset: Dataset) {
     if (this._datasets) {
       const index = this._datasets.indexOf(oldDataset);
-      this.change.emit(
+      this.datasetsChange.emit(
         produce(this._datasets, (draft) => {
           draft[index] = castDraft(newDataset);
         })

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-list/dataset-options/dataset-options.component.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-list/dataset-options/dataset-options.component.ts
@@ -16,7 +16,7 @@ export class DatasetOptionsComponent implements OnInit {
     this._dataset = dataset;
     this.updateForm(dataset);
   }
-  @Output() change = new EventEmitter<Dataset>();
+  @Output() datasetChange = new EventEmitter<Dataset>();
 
   constructor(private fb: FormBuilder, private colorService: DataLayerColorService) {}
 
@@ -44,7 +44,7 @@ export class DatasetOptionsComponent implements OnInit {
         cubicInterpolationMode: formValue.interpolation ? 'monotone' : 'default',
         fill: formValue.fill ? 'stack' : false,
       };
-      this.change.emit(
+      this.datasetChange.emit(
         produce(this._dataset, (draft) => {
           merge(draft, props);
           this.colorService.setColor(draft, formValue.color ?? '');

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-toolbar/data-layer-toolbar/data-layer-toolbar.component.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-toolbar/data-layer-toolbar/data-layer-toolbar.component.ts
@@ -8,12 +8,12 @@ import { DataLayerManagerService } from '../../data-layer/data-layer-manager.ser
 })
 export class DataLayerToolbarComponent implements OnChanges {
   @Input() active: string | null = null;
-  @Output() change = new EventEmitter<string | null>();
+  @Output() activeChange = new EventEmitter<string | null>();
 
   constructor(public layerManager: DataLayerManagerService) {}
 
   ngOnChanges(): void {
-    this.change.emit(this.active);
+    this.activeChange.emit(this.active);
   }
 
   onClick(tool: string | null) {
@@ -22,6 +22,6 @@ export class DataLayerToolbarComponent implements OnChanges {
     } else {
       this.active = tool;
     }
-    this.change.emit(this.active);
+    this.activeChange.emit(this.active);
   }
 }

--- a/projects/showcase/src/app/app.component.html
+++ b/projects/showcase/src/app/app.component.html
@@ -1,4 +1,4 @@
-<data-layer-toolbar [active]="sidenavPanel" (change)="onToolbarChange(sidenav, $event)"></data-layer-toolbar>
+<data-layer-toolbar [active]="sidenavPanel" (activeChange)="onToolbarChange(sidenav, $event)"></data-layer-toolbar>
 <mat-sidenav-container>
   <mat-sidenav mode="side" #sidenav opened>
     <div class="layout-sidebar">


### PR DESCRIPTION
## Overview

Some components had `@Output()` events named “change”. This collided with a built-in event name for input elements, resulting in the event handler getting called unexpectedly when the input change event bubbled up.

This PR changes all of those outputs to use more specific names.

## How it was tested

Ran the app locally and triggered all of the changed events in the UI.

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
