### PR TITLE
Run afterDataLimits callback inside NgZone

### DIFF
--- a/projects/ngx-charts-on-fhir/src/lib/data-layer/data-layer-manager.service.spec.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer/data-layer-manager.service.spec.ts
@@ -3,11 +3,12 @@ import { DataLayerMergeService } from './data-layer-merge.service';
 import { cold, hot, getTestScheduler } from 'jasmine-marbles';
 import { DataLayerColorService } from './data-layer-color.service';
 import { ManagedDataLayer } from './data-layer';
-import { waitForAsync } from '@angular/core/testing';
+import { NgZone } from '@angular/core';
 
 describe('DataLayerManagerService', () => {
   let mergeService: jasmine.SpyObj<DataLayerMergeService>;
   let colorService: jasmine.SpyObj<DataLayerColorService>;
+  let ngZone: jasmine.SpyObj<NgZone>;
 
   // DataLayers
   const a: ManagedDataLayer = { name: 'a', id: 'a', datasets: [], scales: {} };
@@ -21,6 +22,9 @@ describe('DataLayerManagerService', () => {
     // fake colorService sets borderColor because we can't use toHaveBeenCalledWith() for functions that are called with an immer draft
     colorService = jasmine.createSpyObj('DataLayerColorService', ['chooseColorsFromPalette']);
     colorService.chooseColorsFromPalette.and.callFake((l) => l.datasets.forEach((d) => (d.borderColor = '#000000')));
+    // fake zone.run() can just invoke its callback because we don't care about change detection here
+    ngZone = jasmine.createSpyObj('NgZone', ['run'])
+      ngZone.run.and.callFake((fn) => fn());
   });
 
   describe('retrieveAll', () => {
@@ -29,7 +33,7 @@ describe('DataLayerManagerService', () => {
         { name: 'one', retrieve: () => cold('a-c|', { a, c }) },
         { name: 'two', retrieve: () => cold('-b|', { b }) },
       ];
-      const manager = new DataLayerManagerService(services, colorService, mergeService);
+      const manager = new DataLayerManagerService(services, colorService, mergeService, ngZone);
       manager.retrieveAll();
       expect(manager.allLayers$).toBeObservable(
         hot('xyz', {
@@ -42,7 +46,7 @@ describe('DataLayerManagerService', () => {
 
     it('should not change selectedLayers$ when a new layer is retrieved', () => {
       const services = [{ name: 'one', retrieve: () => cold('a-b|', { a, b }) }];
-      const manager = new DataLayerManagerService(services, colorService, mergeService);
+      const manager = new DataLayerManagerService(services, colorService, mergeService, ngZone);
       manager.retrieveAll();
       getTestScheduler().schedule(() => manager.select('a'), 10);
       expect(manager.selectedLayers$).toBeObservable(
@@ -57,7 +61,7 @@ describe('DataLayerManagerService', () => {
   describe('select', () => {
     it('should emit selectedLayers$', () => {
       const services = [{ name: 'one', retrieve: () => cold('a|', { a }) }];
-      const manager = new DataLayerManagerService(services, colorService, mergeService);
+      const manager = new DataLayerManagerService(services, colorService, mergeService, ngZone);
       manager.retrieveAll();
       getTestScheduler().schedule(() => manager.select('a'), 10);
       expect(manager.selectedLayers$).toBeObservable(
@@ -70,7 +74,7 @@ describe('DataLayerManagerService', () => {
 
     it('should enable the layer', () => {
       const services = [{ name: 'one', retrieve: () => cold('a|', { a }) }];
-      const manager = new DataLayerManagerService(services, colorService, mergeService);
+      const manager = new DataLayerManagerService(services, colorService, mergeService, ngZone);
       manager.retrieveAll();
       getTestScheduler().schedule(() => manager.select('a'), 10);
       expect(manager.selectedLayers$).toBeObservable(
@@ -84,7 +88,7 @@ describe('DataLayerManagerService', () => {
     it('should set layer color', () => {
       const layer: ManagedDataLayer = { name: 'a', id: 'a', datasets: [{ data: [] }], scales: {} };
       const services = [{ name: 'one', retrieve: () => cold('a|', { a: layer }) }];
-      const manager = new DataLayerManagerService(services, colorService, mergeService);
+      const manager = new DataLayerManagerService(services, colorService, mergeService, ngZone);
       manager.retrieveAll();
       getTestScheduler().schedule(() => manager.select('a'), 10);
       expect(manager.selectedLayers$).toBeObservable(
@@ -100,10 +104,10 @@ describe('DataLayerManagerService', () => {
       );
     });
 
-    it('should emit $timelineRange when timeline scale limits change', waitForAsync(() => {
+    it('should emit $timelineRange when timeline scale limits change', () => {
       const originalLayer: ManagedDataLayer = { name: 'a', id: 'a', datasets: [], scales: { timeline: {} } };
       const services = [{ name: 'one', retrieve: () => cold('a|', { a: originalLayer }) }];
-      const manager = new DataLayerManagerService(services, colorService, mergeService);
+      const manager = new DataLayerManagerService(services, colorService, mergeService, ngZone);
       let layer: ManagedDataLayer;
       manager.allLayers$.subscribe(([l]) => (layer = l));
       manager.retrieveAll();
@@ -114,11 +118,24 @@ describe('DataLayerManagerService', () => {
           x: { min: 2, max: 3 },
         })
       );
-    }));
+    });
+
+    it('should run afterDataLimits callback within NgZone', () => {
+      const originalLayer: ManagedDataLayer = { name: 'a', id: 'a', datasets: [], scales: { timeline: {} } };
+      const services = [{ name: 'one', retrieve: () => cold('a|', { a: originalLayer }) }];
+      const manager = new DataLayerManagerService(services, colorService, mergeService, ngZone);
+      let layer: ManagedDataLayer;
+      manager.allLayers$.subscribe(([l]) => (layer = l));
+      manager.retrieveAll();
+      getTestScheduler().schedule(() => manager.select('a'), 10);
+      getTestScheduler().schedule(() => (layer.scales?.['timeline'] as any).afterDataLimits({ min: 2, max: 3 }), 20);
+      getTestScheduler().flush();
+      expect(ngZone.run).toHaveBeenCalledTimes(1);
+    });
 
     it('should throw an error if layer is already selected', () => {
       const services = [{ name: 'one', retrieve: () => cold('a|', { a }) }];
-      const manager = new DataLayerManagerService(services, colorService, mergeService);
+      const manager = new DataLayerManagerService(services, colorService, mergeService, ngZone);
       manager.retrieveAll();
       getTestScheduler().flush();
       manager.select('a');
@@ -126,7 +143,7 @@ describe('DataLayerManagerService', () => {
     });
 
     it('should throw an error if layer does not exist', () => {
-      const manager = new DataLayerManagerService([], colorService, mergeService);
+      const manager = new DataLayerManagerService([], colorService, mergeService, ngZone);
       expect(() => manager.select('a')).toThrowError(/not found/);
     });
   });
@@ -134,7 +151,7 @@ describe('DataLayerManagerService', () => {
   describe('remove', () => {
     it('should remove the layer from selectedLayers$', () => {
       const services = [{ name: 'one', retrieve: () => cold('(ab|)', { a, b }) }];
-      const manager = new DataLayerManagerService(services, colorService, mergeService);
+      const manager = new DataLayerManagerService(services, colorService, mergeService, ngZone);
       manager.retrieveAll();
       getTestScheduler().schedule(() => manager.select('a'), 0);
       getTestScheduler().schedule(() => manager.select('b'), 0);
@@ -150,7 +167,7 @@ describe('DataLayerManagerService', () => {
 
     it('should throw an error if layer is not selected', () => {
       const services = [{ name: 'one', retrieve: () => cold('a|', { a }) }];
-      const manager = new DataLayerManagerService(services, colorService, mergeService);
+      const manager = new DataLayerManagerService(services, colorService, mergeService, ngZone);
       manager.retrieveAll();
       getTestScheduler().flush();
       expect(() => manager.remove('a')).toThrowError(/not selected/);
@@ -160,7 +177,7 @@ describe('DataLayerManagerService', () => {
   describe('enable', () => {
     it('should enable the layer in allLayers$', () => {
       const services = [{ name: 'one', retrieve: () => cold('a|', { a }) }];
-      const manager = new DataLayerManagerService(services, colorService, mergeService);
+      const manager = new DataLayerManagerService(services, colorService, mergeService, ngZone);
       manager.retrieveAll();
       getTestScheduler().schedule(() => manager.enable('a'), 10);
       expect(manager.allLayers$).toBeObservable(
@@ -171,10 +188,10 @@ describe('DataLayerManagerService', () => {
       );
     });
 
-    it('should show datasets for the layer in allLayers$', waitForAsync(() => {
+    it('should show datasets for the layer in allLayers$', () => {
       const layer: ManagedDataLayer = { name: 'a', id: 'a', datasets: [{ data: [] }], scales: {} };
       const services = [{ name: 'one', retrieve: () => cold('a|', { a: layer }) }];
-      const manager = new DataLayerManagerService(services, colorService, mergeService);
+      const manager = new DataLayerManagerService(services, colorService, mergeService, ngZone);
       manager.retrieveAll();
       getTestScheduler().schedule(() => manager.enable('a'), 10);
       expect(manager.allLayers$).toBeObservable(
@@ -183,11 +200,11 @@ describe('DataLayerManagerService', () => {
           y: [jasmine.objectContaining({ id: 'a', datasets: [jasmine.objectContaining({ hidden: false })] })],
         })
       );
-    }));
+    });
 
     it('should disable the layer in selectedLayers$ when enabled=false', () => {
       const services = [{ name: 'one', retrieve: () => cold('a|', { a }) }];
-      const manager = new DataLayerManagerService(services, colorService, mergeService);
+      const manager = new DataLayerManagerService(services, colorService, mergeService, ngZone);
       manager.retrieveAll();
       getTestScheduler().schedule(() => manager.select('a'), 10);
       getTestScheduler().schedule(() => manager.enable('a', false), 20);
@@ -203,7 +220,7 @@ describe('DataLayerManagerService', () => {
     it('should hide datasets for the layer in selectedLayers$ when enabled=false', () => {
       const layer: ManagedDataLayer = { name: 'a', id: 'a', datasets: [{ data: [] }], scales: {} };
       const services = [{ name: 'one', retrieve: () => cold('a|', { a: layer }) }];
-      const manager = new DataLayerManagerService(services, colorService, mergeService);
+      const manager = new DataLayerManagerService(services, colorService, mergeService, ngZone);
       manager.retrieveAll();
       getTestScheduler().schedule(() => manager.select('a'), 10);
       getTestScheduler().schedule(() => manager.enable('a', false), 20);
@@ -217,7 +234,7 @@ describe('DataLayerManagerService', () => {
     });
 
     it('should throw an error if layer does not exist', () => {
-      const manager = new DataLayerManagerService([], colorService, mergeService);
+      const manager = new DataLayerManagerService([], colorService, mergeService, ngZone);
       expect(() => manager.enable('a')).toThrowError(/not found/);
     });
   });
@@ -226,7 +243,7 @@ describe('DataLayerManagerService', () => {
     it('should emit updated layer in allLayers$', () => {
       const updatedLayer = { name: 'updated', id: 'a', datasets: [], scales: {} };
       const services = [{ name: 'one', retrieve: () => cold('a|', { a }) }];
-      const manager = new DataLayerManagerService(services, colorService, mergeService);
+      const manager = new DataLayerManagerService(services, colorService, mergeService, ngZone);
       manager.retrieveAll();
       getTestScheduler().schedule(() => manager.update(updatedLayer), 10);
       expect(manager.allLayers$).toBeObservable(
@@ -238,7 +255,7 @@ describe('DataLayerManagerService', () => {
     });
 
     it('should throw an error if layer does not exist', () => {
-      const manager = new DataLayerManagerService([], colorService, mergeService);
+      const manager = new DataLayerManagerService([], colorService, mergeService, ngZone);
       expect(() => manager.enable('a')).toThrowError(/not found/);
     });
   });
@@ -246,7 +263,7 @@ describe('DataLayerManagerService', () => {
   describe('move', () => {
     it('should emit selectedLayers$ in new order', () => {
       const services = [{ name: 'one', retrieve: () => cold('(abc|)', { a, b, c }) }];
-      const manager = new DataLayerManagerService(services, colorService, mergeService);
+      const manager = new DataLayerManagerService(services, colorService, mergeService, ngZone);
       manager.retrieveAll();
       getTestScheduler().schedule(() => manager.select('a'), 0);
       getTestScheduler().schedule(() => manager.select('b'), 0);
@@ -261,7 +278,7 @@ describe('DataLayerManagerService', () => {
     });
 
     it('should throw an error if previousIndex is invalid', () => {
-      const manager = new DataLayerManagerService([], colorService, mergeService);
+      const manager = new DataLayerManagerService([], colorService, mergeService, ngZone);
       expect(() => manager.move(1, 0)).toThrowError(/out of range/);
     });
   });

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer/data-layer-manager.service.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer/data-layer-manager.service.ts
@@ -1,4 +1,4 @@
-import { forwardRef, Inject, Injectable } from '@angular/core';
+import { forwardRef, Inject, Injectable, NgZone } from '@angular/core';
 import { BehaviorSubject, distinctUntilChanged, map, merge, Observable, ReplaySubject } from 'rxjs';
 import { DataLayer, DataLayerCollection, ManagedDataLayer } from './data-layer';
 import { DataLayerColorService } from './data-layer-color.service';
@@ -34,7 +34,8 @@ export class DataLayerManagerService {
   constructor(
     @Inject(DataLayerService) readonly dataLayerServices: DataLayerService[],
     private colorService: DataLayerColorService,
-    private mergeService: DataLayerMergeService
+    private mergeService: DataLayerMergeService,
+    private ngZone: NgZone,
   ) {}
 
   private stateSubject = new BehaviorSubject<DataLayerManagerState>(initialState);
@@ -95,7 +96,7 @@ export class DataLayerManagerService {
         layer.enabled = true;
         this.colorService.chooseColorsFromPalette(layer);
         if (layer.scales?.['timeline']) {
-          layer.scales['timeline'].afterDataLimits = ({ max, min }) => this.timelineRangeSubject.next({ max, min });
+          layer.scales['timeline'].afterDataLimits = ({ max, min }) => this.ngZone.run(() => this.timelineRangeSubject.next({ max, min }));
         }
       })
     );


### PR DESCRIPTION
## Overview

Change detection was not running for changes made in response to chart.js `afterDataLimits` callback. This bug was not apparent because the Analysis component was manually triggering change detection for its dynamic components. But when I tried using `DataLayerManager#timelineRange$` in another template binding, it was not working.

This PR updates `DataLayerManager` to execute the callback inside NgZone.

## How it was tested

- Created a unit test to verify NgZone.run is getting called.
- Added statistics component directly to app.component, bound its input to timelineRange$, and verified that the component updated when I zoom/pan the chart. (this change to app.component is not included in this PR)

## Checklist

- [x] The title contains a short meaningful summary
- [ ] I have added a link to this PR in the Jira issue
- [ ] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)
