### PR TITLE
Fix build errors for medication summary

### DIFF
--- a/projects/ngx-charts-on-fhir/src/lib/analysis-cards/analysis-utils.spec.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/analysis-cards/analysis-utils.spec.ts
@@ -1,6 +1,7 @@
+import { ScatterDataPoint } from 'chart.js';
 import { DeepPartial } from 'chart.js/types/utils';
 import { AnnotationOptions } from 'chartjs-plugin-annotation';
-import { DataLayer, Dataset } from '../data-layer/data-layer';
+import { DataLayer, Dataset, TimelineChartType } from '../data-layer/data-layer';
 import { computeDaysOutOfRange, isReferenceRangeFor } from './analysis-utils';
 
 describe('Analysis Utils', () => {
@@ -26,7 +27,7 @@ describe('Analysis Utils', () => {
 
   describe('computeDaysOutOfRange', () => {
     it('should return the number of days outside of the reference range', () => {
-      const layer: DataLayer = {
+      const layer: DataLayer<TimelineChartType, ScatterDataPoint[]> = {
         name: 'Layer',
         datasets: [
           {

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer/visible-data.service.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer/visible-data.service.ts
@@ -4,7 +4,7 @@ import { OperatorFunction, pipe, map, Observable, combineLatestWith } from 'rxjs
 import { DateRange } from '../analysis/analysis-card-content.component';
 import { ManagedDataLayer, DataLayer, Dataset } from './data-layer';
 import { DataLayerManagerService } from './data-layer-manager.service';
-import { MILLISECONDS_PER_DAY } from '../utils';
+import { isValidScatterDataPoint, MILLISECONDS_PER_DAY } from '../utils';
 import { DataLayerModule } from './data-layer.module';
 
 export type VisibleData = {
@@ -45,7 +45,10 @@ function byMostRecentValue(a: Dataset, b: Dataset) {
   if (ay == null || by == null) {
     return 0;
   }
-  return by - ay;
+  if (typeof ay === 'number' && typeof by === 'number') {
+    return by - ay;
+  }
+  throw new TypeError('Unsupported y-value types');
 }
 
 function filterByDateRange(dateRange$: Observable<{ min: number; max: number }>): OperatorFunction<{ layer: DataLayer; dataset: Dataset }[], VisibleData[]> {
@@ -55,7 +58,7 @@ function filterByDateRange(dateRange$: Observable<{ min: number; max: number }>)
       datasets.map(({ layer, dataset }) => ({
         layer,
         dataset,
-        data: dataset.data.filter((point) => range.min <= point.x && point.x <= range.max),
+        data: dataset.data.filter(isValidScatterDataPoint).filter((point) => range.min <= point.x && point.x <= range.max),
         dateRange: {
           min: new Date(range.min),
           max: new Date(range.max),

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer/visible-data.spec.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer/visible-data.spec.ts
@@ -2,7 +2,7 @@ import { hot } from 'jasmine-marbles';
 import { ManagedDataLayer } from './data-layer';
 import { VisibleDataService } from './visible-data.service';
 
-describe('FhirChartSummaryService', () => {
+describe('VisibleDataService', () => {
   describe('visible$', () => {
     it('should emit when selectedLayers$ changes', () => {
       const a: Partial<ManagedDataLayer>[] = [
@@ -132,7 +132,16 @@ describe('FhirChartSummaryService', () => {
         {
           name: 'Layer',
           enabled: true,
-          datasets: [{ data: [{ x: 0 }, { x: 2 }, { x: 3 }, { x: 5 }] }],
+          datasets: [
+            {
+              data: [
+                { x: 0, y: 0 },
+                { x: 2, y: 0 },
+                { x: 3, y: 0 },
+                { x: 5, y: 0 },
+              ],
+            },
+          ],
         },
       ];
       const manager: any = {
@@ -144,12 +153,15 @@ describe('FhirChartSummaryService', () => {
         hot('xy', {
           x: [
             jasmine.objectContaining({
-              data: [{ x: 2 }, { x: 3 }],
+              data: [
+                { x: 2, y: 0 },
+                { x: 3, y: 0 },
+              ],
             }),
           ],
           y: [
             jasmine.objectContaining({
-              data: [{ x: 5 }],
+              data: [{ x: 5, y: 0 }],
             }),
           ],
         })

--- a/projects/ngx-charts-on-fhir/src/lib/utils.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/utils.ts
@@ -12,9 +12,9 @@ export function isDefined<T>(value: T | null | undefined): value is T {
   return value != null;
 }
 
-export function isValidDataPoint<P>(point: P): point is P & ScatterDataPoint {
+export function isValidScatterDataPoint<P>(point: P): point is P & ScatterDataPoint {
   const p = point as any;
-  return p != null && typeof p === 'object' && p.x != null && p.x > 0 && p.y != null; // y <= 0 is ok
+  return p != null && typeof p === 'object' && p.x != null && p.x > 0 && p.y != null && typeof p.y === 'number'; // y <= 0 is ok
 }
 
 export const MILLISECONDS_PER_DAY = 1000 * 60 * 60 * 24;


### PR DESCRIPTION
## Overview

- Resolves logical conflicts between medication and chart summary branches.
- `VisibleDataService` now filters out string y-values so `$visible.data` only contains valid `ScatterDataPoint`s
- Statistics panel does not really make sense for medications. It currently displays N/A or NaN for most rows. I will open a new issue for that. This PR only fixes the build errors.

## How it was tested

Added some medications and observations to the chart

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [x] I have included screen shots for changes that affect the user interface
- [x] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
