### PR TITLE
RT-549 Annotation checkbox disables the wrong annotation

### DIFF
--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-list/annotation-list/annotation-list.component.html
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-list/annotation-list/annotation-list.component.html
@@ -2,16 +2,16 @@
 
 <div class="scrolling-list">
   <mat-accordion displayMode="flat" multi="true">
-    <mat-expansion-panel *ngFor="let annotation of _annotations; trackBy: trackByIndex" expanded="true">
+    <mat-expansion-panel *ngFor="let annotation of _annotations; let i = index; trackBy: trackByIndex" expanded="true">
       <mat-expansion-panel-header>
         <mat-panel-title>
           <mat-checkbox
             (click)="$event.stopPropagation()"
-            (change)="onCheckboxChange(annotation, $event)"
+            (change)="onCheckboxChange(i, $event)"
             [checked]="annotation.display"
             [title]="annotation.display ? 'Show this annotation on the chart' : 'Hide this annotation on the chart'"
             color="primary"
-            id="annotationDisplayCheckBox"
+            [id]="i + 'annotationcheckbox'"
           ></mat-checkbox>
           {{ annotation.label.content }}
         </mat-panel-title>

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-list/annotation-list/annotation-list.component.spec.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-list/annotation-list/annotation-list.component.spec.ts
@@ -32,7 +32,7 @@ describe('DatasetAnnotationListComponent', () => {
       const annotations = [{ label: { content: 'Test', display: true }, display: false }];
       component.annotations = annotations;
       let expectedOutput: any = [{ label: { content: 'Test', display: true }, display: true }];
-      let checkBoxHarness = await loader.getHarness(MatCheckboxHarness.with({ selector: "[id='annotationDisplayCheckBox']" }));
+      let checkBoxHarness = await loader.getHarness(MatCheckboxHarness.with({ selector: '[id]' }));
       await checkBoxHarness.check();
       expect(emitted).toEqual(expectedOutput);
     });
@@ -42,7 +42,7 @@ describe('DatasetAnnotationListComponent', () => {
       const annotations = [{ label: { content: 'Test', display: true }, display: true }];
       component.annotations = annotations;
       let expectedOutput: any = [{ label: { content: 'Test', display: true }, display: false }];
-      let checkBoxHarness = await loader.getHarness(MatCheckboxHarness.with({ selector: "[id='annotationDisplayCheckBox']" }));
+      let checkBoxHarness = await loader.getHarness(MatCheckboxHarness.with({ selector: '[id]' }));
       await checkBoxHarness.uncheck();
       expect(emitted).toEqual(expectedOutput);
     });

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-list/annotation-list/annotation-list.component.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-list/annotation-list/annotation-list.component.ts
@@ -16,9 +16,8 @@ export class AnnotationListComponent {
 
   @Output() annotationsChange = new EventEmitter<any[]>();
 
-  onCheckboxChange(annotation: any, event: MatCheckboxChange) {
+  onCheckboxChange(index: any, event: MatCheckboxChange) {
     if (this._annotations) {
-      const index = this._annotations.indexOf(annotation);
       this.annotationsChange.emit(
         produce(this._annotations, (draft) => {
           draft[index].display = event.checked;

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-list/annotation-options/annotation-options.component.spec.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-list/annotation-options/annotation-options.component.spec.ts
@@ -95,7 +95,7 @@ describe('AnnotationOptionsComponent', () => {
 
   it('should emit annotation change event with updated annotations', async () => {
     let annotation = { label: { content: 'Test' }, yMin: 100, yMax: 200, backgroundColor: '#FFFFFF' };
-    let updatedAnnotation = { label: { content: 'Updated test' }, yMin: 100, yMax: 200, backgroundColor: '#FFFFFF' };
+    let updatedAnnotation = { label: { content: 'Updated test' }, yMin: 100, yMax: 200, backgroundColor: '#FFFFFF33' };
     component.annotation = annotation;
     let emitted: any;
     component.annotationChange.subscribe((e: any) => {

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer/data-layer-color.service.spec.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer/data-layer-color.service.spec.ts
@@ -31,7 +31,7 @@ describe('DataLayerColorService', () => {
     it('should return the annotation background color', inject([DataLayerColorService], (service: DataLayerColorService) => {
       const annotation: any = {
         label: {},
-        backgroundColor: '#ECF0F9',
+        backgroundColor: '#ECF0F933',
       };
       expect(service.getAnnotationColor(annotation)).toEqual(annotation.backgroundColor);
     }));

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer/data-layer-color.service.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer/data-layer-color.service.ts
@@ -22,17 +22,17 @@ export class DataLayerColorService {
     }
   }
 
-  setAnnotationColor(annotation: any, color: string): void {
+  setAnnotationColor(annotation: any, color?: string): void {
     const line = annotation;
     line.backgroundColor = color + '33'; // temporary dirty hack to set opacity. assumes color is in 6-character hex format.
   }
 
   getAnnotationColor(annotation: any): string | undefined {
     const color = annotation.backgroundColor;
-    if (typeof color === 'string') {
-      return color;
+    if (typeof color === 'string' && !color.includes('33')) {
+      return color + '33';
     }
-    return undefined;
+    return color;
   }
 
   setColor(dataset: Dataset, color: string): void {


### PR DESCRIPTION
## Overview

- Fixed annotation checkbox disables the wrong annotation issue.


## How it was tested

- Tested it by launching charts-on-fhir locally.
- Ran unit test cases locally.

## Checklist

- [X] The title contains a short meaningful summary
- [X] I have added a link to this PR in the Jira issue
- [X] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [X] I have updated unit tests
- [X] I have run unit tests locally
- [ ] I have updated documentation (including README)
