### PR TITLE
FHIR R4 Logica Sandbox

### DIFF
--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-browser/data-layer-browser.component.css
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-browser/data-layer-browser.component.css
@@ -31,13 +31,12 @@
   padding: 16px;
 }
 
-
 .progress-bar-section {
   display: flex;
   align-content: center;
   align-items: center;
   height: 60px;
-  margin: 10px 10px 10px 10px
+  margin: 10px 10px 10px 10px;
 }
 
 .progress-bar-margin {

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-browser/data-layer-browser.component.html
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-browser/data-layer-browser.component.html
@@ -4,29 +4,22 @@
     <mat-form-field class="filter" appearance="outline">
       <mat-icon matPrefix fontIcon="search"></mat-icon>
       <input matInput [formControl]="filterControl" placeholder="Search" />
-      <button mat-icon-button matSuffix (click)="filterControl.setValue('')"><mat-icon
-          fontIcon="close"></mat-icon></button>
+      <button mat-icon-button matSuffix (click)="filterControl.setValue('')"><mat-icon fontIcon="close"></mat-icon></button>
     </mat-form-field>
   </header>
   <section class="progress-bar-section">
-    <mat-progress-bar *ngIf="(layerManager.loading$ | async)"
-        class="progress-bar-margin"
-        mode="indeterminate">
-    </mat-progress-bar>
+    <mat-progress-bar *ngIf="layerManager.loading$ | async" class="progress-bar-margin" mode="indeterminate"> </mat-progress-bar>
   </section>
 
-
   <div class="scroll-container">
-  
-    <table mat-table [dataSource]="dataSource" [trackBy]="getLayerId" class="data-layer-table" matSort
-      aria-label="Available data layers">
+    <table mat-table [dataSource]="dataSource" [trackBy]="getLayerId" class="data-layer-table" matSort aria-label="Available data layers">
       <ng-container matColumnDef="name">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>Name</th>
         <td mat-cell *matCellDef="let layer" class="ellipsis">{{ layer.name }}</td>
       </ng-container>
       <ng-container matColumnDef="category">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>Category</th>
-        <td mat-cell *matCellDef="let layer">{{ layer.category }}</td>
+        <td mat-cell *matCellDef="let layer">{{ getCategory(layer) }}</td>
       </ng-container>
       <ng-container matColumnDef="datapoints">
         <th mat-header-cell *matHeaderCellDef mat-sort-header arrowPosition="before">#</th>
@@ -35,8 +28,7 @@
       <ng-container matColumnDef="add">
         <th mat-header-cell *matHeaderCellDef></th>
         <td mat-cell *matCellDef="let layer">
-          <button mat-mini-fab color="primary" (click)="layerManager.select(layer.id)"><mat-icon
-              fontIcon="add"></mat-icon></button>
+          <button mat-mini-fab color="primary" (click)="layerManager.select(layer.id)"><mat-icon fontIcon="add"></mat-icon></button>
         </td>
       </ng-container>
 

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-browser/data-layer-browser.component.spec.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-browser/data-layer-browser.component.spec.ts
@@ -15,7 +15,7 @@ const mockLayerManager = {
   availableLayers$: EMPTY,
   selectedLayers$: EMPTY,
   timelineRange$: EMPTY,
-  loading$: EMPTY
+  loading$: EMPTY,
 };
 
 describe('DataLayerBrowserComponent', () => {

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-browser/data-layer-browser.component.spec.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-browser/data-layer-browser.component.spec.ts
@@ -1,6 +1,8 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+import { MatSortHeaderHarness } from '@angular/material/sort/testing';
 import { MatTableHarness } from '@angular/material/table/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { BehaviorSubject, EMPTY } from 'rxjs';
@@ -76,10 +78,78 @@ describe('DataLayerBrowserComponent', () => {
     layerManager.availableLayers$.next(layers);
     const table = await loader.getHarness(MatTableHarness);
     const values = await table.getCellTextByColumnName();
-    expect(values).toEqual(jasmine.objectContaining({
-      name: jasmine.objectContaining({ text: ['One', 'Two'] }),
-      category: jasmine.objectContaining({ text: ['A, B', 'C, D'] }),
-      datapoints: jasmine.objectContaining({ text: ['1', '2'] }),
-    }));
+    expect(values).toEqual(
+      jasmine.objectContaining({
+        name: jasmine.objectContaining({ text: ['One', 'Two'] }),
+        category: jasmine.objectContaining({ text: ['A, B', 'C, D'] }),
+        datapoints: jasmine.objectContaining({ text: ['1', '2'] }),
+      })
+    );
   });
+
+  it('should filter layers by category', async () => {
+    const layers: ManagedDataLayer[] = [
+      {
+        id: '1',
+        name: 'One',
+        category: ['A'],
+        datasets: [{ data: [] }],
+        scales: {},
+      },
+      {
+        id: '2',
+        name: 'Two',
+        category: ['C'],
+        datasets: [{ data: [] }],
+        scales: {},
+      },
+    ];
+    layerManager.availableLayers$.next(layers);
+    const filter = await loader.getHarness(MatInputHarness);
+    await filter.setValue('A');
+    const table = await loader.getHarness(MatTableHarness);
+    const values = await table.getCellTextByColumnName();
+    expect(values).toEqual(
+      jasmine.objectContaining({
+        category: jasmine.objectContaining({ text: ['A'] }),
+      })
+    );
+  });
+
+  it('should sort layers by category', async () => {
+    const layers: ManagedDataLayer[] = [
+      {
+        id: '1',
+        name: 'One',
+        category: ['B'],
+        datasets: [{ data: [] }],
+        scales: {},
+      },
+      {
+        id: '2',
+        name: 'Two',
+        category: ['C'],
+        datasets: [{ data: [] }],
+        scales: {},
+      },
+      {
+        id: '3',
+        name: 'Three',
+        category: ['A'],
+        datasets: [{ data: [] }],
+        scales: {},
+      },
+    ];
+    layerManager.availableLayers$.next(layers);
+    const categorySort = await loader.getHarness(MatSortHeaderHarness.with({label: 'Category'}));
+    await categorySort.click();
+    const table = await loader.getHarness(MatTableHarness);
+    const values = await table.getCellTextByColumnName();
+    expect(values).toEqual(
+      jasmine.objectContaining({
+        category: jasmine.objectContaining({ text: ['A', 'B', 'C'] }),
+      })
+    );
+  });
+
 });

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-browser/data-layer-browser.component.spec.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-browser/data-layer-browser.component.spec.ts
@@ -1,6 +1,10 @@
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatTableHarness } from '@angular/material/table/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { EMPTY } from 'rxjs';
+import { BehaviorSubject, EMPTY } from 'rxjs';
+import { ManagedDataLayer } from '../data-layer/data-layer';
 import { DataLayerColorService, COLOR_PALETTE } from '../data-layer/data-layer-color.service';
 import { DataLayerManagerService } from '../data-layer/data-layer-manager.service';
 import { DataLayerBrowserComponent } from './data-layer-browser.component';
@@ -11,33 +15,71 @@ const mockColorService = {
   setColor: () => {},
 };
 
-const mockLayerManager = {
-  availableLayers$: EMPTY,
-  selectedLayers$: EMPTY,
-  timelineRange$: EMPTY,
-  loading$: EMPTY,
-};
+class MockLayerManager {
+  availableLayers$ = new BehaviorSubject<ManagedDataLayer[]>([]);
+  selectedLayers$ = EMPTY;
+  timelineRange$ = EMPTY;
+  loading$ = EMPTY;
+}
 
 describe('DataLayerBrowserComponent', () => {
   let component: DataLayerBrowserComponent;
   let fixture: ComponentFixture<DataLayerBrowserComponent>;
+  let loader: HarnessLoader;
+  let layerManager: MockLayerManager;
 
   beforeEach(async () => {
+    layerManager = new MockLayerManager();
     await TestBed.configureTestingModule({
       imports: [DataLayerBrowserModule, NoopAnimationsModule],
       providers: [
-        { provide: DataLayerManagerService, useValue: mockLayerManager },
+        { provide: DataLayerManagerService, useValue: layerManager },
         { provide: DataLayerColorService, useValue: mockColorService },
         { provide: COLOR_PALETTE, useValue: ['#000000', '#ffffff'] },
       ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(DataLayerBrowserComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should display available layers', async () => {
+    const layers: ManagedDataLayer[] = [
+      {
+        id: '1',
+        name: 'One',
+        category: ['A', 'B'],
+        datasets: [{ data: [{ x: 1, y: 1 }] }],
+        scales: {},
+      },
+      {
+        id: '2',
+        name: 'Two',
+        category: ['C', 'D'],
+        datasets: [
+          {
+            data: [
+              { x: 2, y: 2 },
+              { x: 3, y: 3 },
+            ],
+          },
+        ],
+        scales: {},
+      },
+    ];
+    layerManager.availableLayers$.next(layers);
+    const table = await loader.getHarness(MatTableHarness);
+    const values = await table.getCellTextByColumnName();
+    expect(values).toEqual(jasmine.objectContaining({
+      name: jasmine.objectContaining({ text: ['One', 'Two'] }),
+      category: jasmine.objectContaining({ text: ['A, B', 'C, D'] }),
+      datapoints: jasmine.objectContaining({ text: ['1', '2'] }),
+    }));
   });
 });

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-browser/data-layer-browser.component.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-browser/data-layer-browser.component.ts
@@ -25,11 +25,12 @@ export class DataLayerBrowserComponent implements OnInit, AfterViewInit {
   getLayerId = (index: number, layer: DataLayer) => layer.name;
   getDatasetCount = (layer: DataLayer) => layer.datasets.length;
   getDatapointCount = (layer: DataLayer) => sum(layer.datasets.map((dataset) => dataset.data.length));
+  getCategory = (layer: DataLayer) => layer.category?.join(', ') ?? '';
   ngOnInit(): void {
     this.layerManager.availableLayers$.subscribe((layers) => (this.dataSource.data = layers));
     this.dataSource.filterPredicate = (layer, filter) =>
       layer.name.toLowerCase().includes(filter) ||
-      layer.category?.toLowerCase().includes(filter) ||
+      layer.category?.some((category) => category.toLowerCase().includes(filter)) ||
       layer.datasets.some((dataset) => dataset.label?.toLowerCase().includes(filter));
     this.filterControl.valueChanges.subscribe((value) => (this.dataSource.filter = value?.trim().toLowerCase() ?? ''));
   }
@@ -38,6 +39,8 @@ export class DataLayerBrowserComponent implements OnInit, AfterViewInit {
       this.dataSource.sortingDataAccessor = (item, property) => {
         if (property === 'datapoints') {
           return this.getDatapointCount(item);
+        } else if (property === 'category') {
+          return this.getCategory(item);
         }
         return String(item[property as keyof typeof item]);
       };

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-browser/data-layer-browser.module.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-browser/data-layer-browser.module.ts
@@ -11,6 +11,6 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
 @NgModule({
   declarations: [DataLayerBrowserComponent],
   imports: [CommonModule, MatIconModule, MatTableModule, MatSortModule, MatInputModule, MatButtonModule, ReactiveFormsModule, MatProgressBarModule],
-  exports: [DataLayerBrowserComponent]
+  exports: [DataLayerBrowserComponent],
 })
 export class DataLayerBrowserModule {}

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-list/data-layer-options/data-layer-options.component.spec.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-list/data-layer-options/data-layer-options.component.spec.ts
@@ -43,7 +43,7 @@ describe('DataLayerOptionsComponent', () => {
       component.layer = {
         id: '-109669932',
         name: 'Blood Pressure',
-        category: 'vital-signs',
+        category: ['vital-signs'],
         datasets: [
           {
             label: 'Diastolic Blood Pressure',
@@ -75,7 +75,7 @@ describe('DataLayerOptionsComponent', () => {
       component.layer = {
         id: '-109669932',
         name: 'Blood Pressure',
-        category: 'vital-signs',
+        category: ['vital-signs'],
         datasets: [],
         scales: {},
         annotations: [],

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer/data-layer-manager.service.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer/data-layer-manager.service.ts
@@ -55,7 +55,7 @@ export class DataLayerManagerService {
   private timelineRangeSubject = new ReplaySubject<{ min: number; max: number }>();
   timelineRange$ = this.timelineRangeSubject.pipe(throttleTime(100, undefined, { leading: true, trailing: true }));
 
-  loading$ = new BehaviorSubject<boolean>(false); 
+  loading$ = new BehaviorSubject<boolean>(false);
 
   /**
    * Retrieve layers from all of the injected [DataLayerService]s.
@@ -76,9 +76,11 @@ export class DataLayerManagerService {
           layers: this.mergeService.merge(this.state.layers, layer),
         }),
       error: (err) => console.error(err),
-      complete: () => {this.loading$.next(false);},
+      complete: () => {
+        this.loading$.next(false);
+      },
     });
-  } 
+  }
 
   select(id: string) {
     if (!this.state.layers[id]) {

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer/data-layer.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer/data-layer.ts
@@ -13,7 +13,7 @@ export type TimelineDataPoint = {
 /** A collection of closely-related data, metadata, and annotations */
 export type DataLayer<T extends ChartType = TimelineChartType, D = TimelineDataPoint[]> = {
   name: string;
-  category?: string;
+  category?: string[];
   scales: DeepPartial<ScaleChartOptions<T>>['scales'];
   datasets: ChartDataset<T, D>[];
   annotations?: ChartAnnotations;

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-converter/fhir-converter.service.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-converter/fhir-converter.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@angular/core';
-import { Bundle } from 'fhir/r2';
+import { Bundle } from 'fhir/r4';
 import { DataLayer } from '../data-layer/data-layer';
 import { FhirConverterModule } from './fhir-converter.module';
 import { MultiMapper } from './multi-mapper.service';

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/component-observation-mapper.service.spec.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/component-observation-mapper.service.spec.ts
@@ -157,5 +157,23 @@ describe('ComponentObservationMapper', () => {
         })
       );
     });
+
+    it('should map category', () => {
+      const observation: ComponentObservation = {
+        resourceType: 'Observation',
+        status: 'final',
+        code: { text: 'text' },
+        category: [{ coding: [{ display: 'A' }] }, { coding: [{ display: 'B' }] }],
+        effectiveDateTime: new Date().toISOString(),
+        component: [
+          {
+            code: { text: 'component' },
+            valueQuantity: { value: 7, unit: 'unit' },
+          },
+        ],
+      };
+      const mapper = new ComponentObservationMapper({}, {}, {});
+      expect(mapper.map(observation).category).toEqual(['A', 'B']);
+    });
   });
 });

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/component-observation-mapper.service.spec.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/component-observation-mapper.service.spec.ts
@@ -1,4 +1,4 @@
-import { Observation } from 'fhir/r2';
+import { Observation } from 'fhir/r4';
 import { ComponentObservation, ComponentObservationMapper } from './component-observation-mapper.service';
 
 describe('ComponentObservationMapper', () => {

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/component-observation-mapper.service.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/component-observation-mapper.service.ts
@@ -1,10 +1,10 @@
 import { Injectable, Inject, forwardRef } from '@angular/core';
 import { ScaleOptions } from 'chart.js';
-import { Observation, ObservationComponent } from 'fhir/r2';
+import { Observation, ObservationComponent } from 'fhir/r4';
 import { merge } from 'lodash-es';
 import { DataLayer } from '../data-layer/data-layer';
 import { Mapper } from '../fhir-converter/multi-mapper.service';
-import { ChartAnnotation } from '../utils';
+import { ChartAnnotation, isDefined } from '../utils';
 import { TIME_SCALE_OPTIONS, LINEAR_SCALE_OPTIONS, ANNOTATION_OPTIONS } from './fhir-mapper-options';
 import { FhirMappersModule } from './fhir-mappers.module';
 
@@ -55,7 +55,7 @@ export class ComponentObservationMapper implements Mapper<ComponentObservation> 
     const scaleName = `${resource.code.text} (${resource.component[0].valueQuantity.unit})`;
     return {
       name: resource.code.text,
-      category: resource.category?.text,
+      category: resource.category?.flatMap((c) => c.coding?.map((coding) => coding.display)).filter(isDefined),
       datasets: resource.component
         .sort((a, b) => a.code.text.localeCompare(b.code.text))
         .map((component) => ({

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/fhir-mapper-options.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/fhir-mapper-options.ts
@@ -45,7 +45,7 @@ const defaultCategoryScaleOptions: ScaleOptions<'category'> = {
   },
   ticks: {
     autoSkip: false,
-  }
+  },
 } as const;
 
 export const ANNOTATION_OPTIONS = new InjectionToken<ChartAnnotation>('Annotation Options', {

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/fhir-mappers.module.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/fhir-mappers.module.ts
@@ -1,5 +1,3 @@
 import { NgModule } from '@angular/core';
 @NgModule()
-export class FhirMappersModule {
-    
-}
+export class FhirMappersModule {}

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/simple-medication-mapper.service.spec.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/simple-medication-mapper.service.spec.ts
@@ -1,22 +1,28 @@
-import { Medication, MedicationOrder, Observation } from 'fhir/r2';
+import { MedicationRequest } from 'fhir/r4';
 import { SimpleMedication, SimpleMedicationMapper } from './simple-medication-mapper.service';
 
 describe('SimpleMedicationMapper', () => {
   describe('canMap', () => {
     it('should return true for a SimpleMedication', () => {
       const medication: SimpleMedication = {
-        resourceType: 'MedicationOrder',
+        resourceType: 'MedicationRequest',
         medicationCodeableConcept: { text: 'text' },
-        dateWritten: new Date().toISOString(),
+        authoredOn: new Date().toISOString(),
+        intent: 'order',
+        status: 'completed',
+        subject: {},
       };
       const mapper = new SimpleMedicationMapper({}, {});
       expect(mapper.canMap(medication)).toBe(true);
     });
 
-    it('should return false for an Medication with no dateWritten', () => {
-      const medication: MedicationOrder = {
-        resourceType: 'MedicationOrder',
+    it('should return false for an Medication with no authoredOn', () => {
+      const medication: MedicationRequest = {
+        resourceType: 'MedicationRequest',
         medicationCodeableConcept: { text: 'text' },
+        intent: 'order',
+        status: 'completed',
+        subject: {},
       };
       const mapper = new SimpleMedicationMapper({}, {});
       expect(mapper.canMap(medication)).toBe(false);
@@ -24,12 +30,15 @@ describe('SimpleMedicationMapper', () => {
   });
 
   describe('map', () => {
-    it('should map dateWritten time to x value in milliseconds', () => {
+    it('should map authoredOn time to x value in milliseconds', () => {
       const date = new Date();
       const medication: SimpleMedication = {
-        resourceType: 'MedicationOrder',
+        resourceType: 'MedicationRequest',
         medicationCodeableConcept: { text: 'text' },
-        dateWritten: date.toISOString(),
+        authoredOn: date.toISOString(),
+        intent: 'order',
+        status: 'completed',
+        subject: {},
       };
       const mapper = new SimpleMedicationMapper({}, {});
       expect(mapper.map(medication).datasets[0].data[0].x).toEqual(date.getTime());
@@ -37,9 +46,12 @@ describe('SimpleMedicationMapper', () => {
 
     it('should map medicationCodeableConcept.text to y value', () => {
       const medication: SimpleMedication = {
-        resourceType: 'MedicationOrder',
+        resourceType: 'MedicationRequest',
         medicationCodeableConcept: { text: 'text' },
-        dateWritten: new Date().toISOString(),
+        authoredOn: new Date().toISOString(),
+        intent: 'order',
+        status: 'completed',
+        subject: {},
       };
       const mapper = new SimpleMedicationMapper({}, {});
       expect(mapper.map(medication).datasets[0].data[0].y).toEqual('text');
@@ -47,9 +59,12 @@ describe('SimpleMedicationMapper', () => {
 
     it('should return a layer with a timeline scale', () => {
       const medication: SimpleMedication = {
-        resourceType: 'MedicationOrder',
+        resourceType: 'MedicationRequest',
         medicationCodeableConcept: { text: 'text' },
-        dateWritten: new Date().toISOString(),
+        authoredOn: new Date().toISOString(),
+        intent: 'order',
+        status: 'completed',
+        subject: {},
       };
       const mapper = new SimpleMedicationMapper({ type: 'time' }, {});
       expect(mapper.map(medication).scales?.['timeline']).toEqual({ type: 'time' });

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/simple-medication-mapper.service.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/simple-medication-mapper.service.ts
@@ -1,24 +1,24 @@
 import { Injectable, Inject, forwardRef } from '@angular/core';
 import { ScaleOptions } from 'chart.js';
-import { MedicationOrder } from 'fhir/r2';
+import { MedicationRequest } from 'fhir/r4';
 import { merge } from 'lodash-es';
 import { DataLayer } from '../data-layer/data-layer';
 import { Mapper } from '../fhir-converter/multi-mapper.service';
 import { TIME_SCALE_OPTIONS, CATEGORY_SCALE_OPTIONS } from './fhir-mapper-options';
 import { FhirMappersModule } from './fhir-mappers.module';
 
-/** Required properties for mapping a MedicationOrder with [SimpleMedicationMapper] */
+/** Required properties for mapping a MedicationRequest with [SimpleMedicationMapper] */
 export type SimpleMedication = {
   medicationCodeableConcept: {
     text: string;
   };
-  dateWritten: string;
-} & MedicationOrder;
-export function isMedication(resource: MedicationOrder): resource is SimpleMedication {
-  return !!(resource.resourceType === 'MedicationOrder' && resource.dateWritten && resource.medicationCodeableConcept?.text);
+  authoredOn: string;
+} & MedicationRequest;
+export function isMedication(resource: MedicationRequest): resource is SimpleMedication {
+  return !!(resource.resourceType === 'MedicationRequest' && resource.authoredOn && resource.medicationCodeableConcept?.text);
 }
 
-/** Maps a FHIR MedicationOrder resource that only has a dateWritten and no supply duration */
+/** Maps a FHIR MedicationRequest resource that only has an `authoredOn` and no supply duration */
 @Injectable({
   providedIn: forwardRef(() => FhirMappersModule),
 })
@@ -31,7 +31,7 @@ export class SimpleMedicationMapper implements Mapper<SimpleMedication> {
   map(resource: SimpleMedication): DataLayer {
     return {
       name: resource?.medicationCodeableConcept?.text,
-      category: 'Medication',
+      category: ['medication'],
       datasets: [
         {
           label: resource?.medicationCodeableConcept?.text,
@@ -39,7 +39,7 @@ export class SimpleMedicationMapper implements Mapper<SimpleMedication> {
           indexAxis: 'y',
           data: [
             {
-              x: new Date(resource.dateWritten).getTime(),
+              x: new Date(resource.authoredOn).getTime(),
               y: resource?.medicationCodeableConcept?.text,
             },
           ],

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/simple-observation-mapper.service.spec.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/simple-observation-mapper.service.spec.ts
@@ -1,4 +1,4 @@
-import { Observation } from 'fhir/r2';
+import { Observation } from 'fhir/r4';
 import { SimpleObservation, SimpleObservationMapper } from './simple-observation-mapper.service';
 
 describe('SimpleObservationMapper', () => {

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/simple-observation-mapper.service.spec.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/simple-observation-mapper.service.spec.ts
@@ -104,5 +104,18 @@ describe('SimpleObservationMapper', () => {
         })
       );
     });
+
+    it('should map category', () => {
+      const observation: SimpleObservation = {
+        resourceType: 'Observation',
+        status: 'final',
+        code: { text: 'text' },
+        category: [{ coding: [{ display: 'A' }] }, { coding: [{ display: 'B' }] }],
+        effectiveDateTime: new Date().toISOString(),
+        valueQuantity: { value: 7, unit: 'unit' },
+      };
+      const mapper = new SimpleObservationMapper({}, {}, {});
+      expect(mapper.map(observation).category).toEqual(['A', 'B']);
+    });
   });
 });

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/simple-observation-mapper.service.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/simple-observation-mapper.service.ts
@@ -1,10 +1,10 @@
 import { Injectable, Inject, forwardRef } from '@angular/core';
 import { ScaleOptions } from 'chart.js';
-import { Observation } from 'fhir/r2';
+import { Observation } from 'fhir/r4';
 import { merge } from 'lodash-es';
 import { DataLayer } from '../data-layer/data-layer';
 import { Mapper } from '../fhir-converter/multi-mapper.service';
-import { ChartAnnotation } from '../utils';
+import { ChartAnnotation, isDefined } from '../utils';
 import { TIME_SCALE_OPTIONS, LINEAR_SCALE_OPTIONS, ANNOTATION_OPTIONS } from './fhir-mapper-options';
 import { FhirMappersModule } from './fhir-mappers.module';
 
@@ -44,7 +44,7 @@ export class SimpleObservationMapper implements Mapper<SimpleObservation> {
     const scaleName = `${resource.code.text} (${resource.valueQuantity.unit})`;
     return {
       name: resource.code.text,
-      category: resource.category?.text,
+      category: resource.category?.flatMap((c) => c.coding?.map((coding) => coding.display)).filter(isDefined),
       datasets: [
         {
           label: resource.code.text,

--- a/projects/showcase/src/app/datasets/blood-pressure-mapper.ts
+++ b/projects/showcase/src/app/datasets/blood-pressure-mapper.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from '@angular/core';
 import { merge } from 'lodash-es';
-import { Coding, Observation } from 'fhir/r2';
+import { Coding, Observation } from 'fhir/r4';
 import {
   ComponentObservation,
   ANNOTATION_OPTIONS,

--- a/projects/showcase/src/app/datasets/fhir-data.service.spec.ts
+++ b/projects/showcase/src/app/datasets/fhir-data.service.spec.ts
@@ -1,28 +1,31 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { Bundle, MedicationOrder } from 'fhir/r2';
+import { Bundle, MedicationRequest } from 'fhir/r4';
 import { FhirDataService } from './fhir-data.service';
 
 describe('postService (HttpClientTestingModule)', () => {
   let fhirdataService: FhirDataService;
   let httpTestingController: HttpTestingController;
-  let medicationBundle: Bundle<MedicationOrder> = {
+  let medicationBundle: Bundle<MedicationRequest> = {
     resourceType: 'Bundle',
-    id: 'f3772a8e-591d-4d9b-a985-0b29fbd92522',
     type: 'searchset',
-    total: 2,
-
     entry: [
       {
         resource: {
-          resourceType: 'MedicationOrder',
+          resourceType: 'MedicationRequest',
           id: '173531',
+          intent: 'order',
+          status: 'completed',
+          subject: {},
         },
       },
       {
         resource: {
-          resourceType: 'MedicationOrder',
+          resourceType: 'MedicationRequest',
           id: '173532',
+          intent: 'order',
+          status: 'completed',
+          subject: {},
         },
       },
     ],
@@ -37,9 +40,9 @@ describe('postService (HttpClientTestingModule)', () => {
     httpTestingController = TestBed.inject(HttpTestingController);
   });
 
-  describe('getMedicationsOrder()', () => {
-    it('should return medication bundle when getMedicationsOrder() is called', (done: DoneFn) => {
-      fhirdataService.getMedicationsOrder().subscribe((data) => {
+  describe('getMedicationRequests()', () => {
+    it('should return medication bundle when getMedicationRequests() is called', (done: DoneFn) => {
+      fhirdataService.getMedicationRequests().subscribe((data) => {
         expect(data).toEqual(medicationBundle);
         done();
       });

--- a/projects/showcase/src/app/datasets/fhir-data.service.ts
+++ b/projects/showcase/src/app/datasets/fhir-data.service.ts
@@ -1,33 +1,25 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Bundle, MedicationOrder, Observation } from 'fhir/r2';
+import { Bundle, MedicationRequest, Observation } from 'fhir/r4';
 import { delay, EMPTY, expand, Observable, of, tap } from 'rxjs';
 
-const server = 'https://fhir2-internal.elimuinformatics.com/baseDstu2';
-const loganSmith = '78193';
-const trentLasher = '117335';
-const stanleyGeorge = '115534';
-const kautzer186 = '170913';
-const patient = kautzer186;
+const server = 'https://api.logicahealth.org/chartsonfhir/open';
+const vonRueden376 = '14635';
+const baumbach677 = '15134';
+const wolf938 = '20920';
+const patient = wolf938;
 
 @Injectable({ providedIn: 'root' })
 export class FhirDataService {
-  server = 'https://fhir2-internal.elimuinformatics.com/baseDstu2'
-  patient = '170913';
-  url = `${server}/MedicationOrder?patient=${patient}&_count=100`
+  url = `${server}/MedicationRequest?patient=${patient}&_count=100`;
   constructor(private http: HttpClient) {}
 
   getObservations() {
-    return this.http.get<Bundle<Observation>>(`${server}/Observation?patient=${patient}&_count=100`).pipe(
-      expand((result) => this.getNextBundle(result).pipe(delay(100))) // todo: remove this delay
-    );
+    return this.http.get<Bundle<Observation>>(`${server}/Observation?patient=${patient}&_count=100`).pipe(expand((result) => this.getNextBundle(result)));
   }
 
-
-  getMedicationsOrder() {
-    return this.http.get<Bundle<MedicationOrder>>(this.url).pipe(
-      expand((result) => this.getNextBundle(result).pipe(delay(100))) // todo: remove this delay
-    );
+  getMedicationRequests() {
+    return this.http.get<Bundle<MedicationRequest>>(this.url).pipe(expand((result) => this.getNextBundle(result)));
   }
 
   getBloodPressureObservations() {

--- a/projects/showcase/src/app/datasets/medications.service.ts
+++ b/projects/showcase/src/app/datasets/medications.service.ts
@@ -12,6 +12,6 @@ export class MedicationLayerService extends DataLayerService {
   }
   name = 'Medications';
   retrieve = () => {
-    return this.fhir.getMedicationsOrder().pipe(mergeMap((bundle) => from(this.converter.convert(bundle))));
+    return this.fhir.getMedicationRequests().pipe(mergeMap((bundle) => from(this.converter.convert(bundle))));
   };
 }

--- a/projects/showcase/src/app/providers/data-layer-providers.ts
+++ b/projects/showcase/src/app/providers/data-layer-providers.ts
@@ -6,5 +6,5 @@ import { ObservationLayerService } from '../datasets/observations.service';
 export const dataLayerProviders = [
   { provide: DataLayerService, useExisting: ExampleDataset, multi: true },
   { provide: DataLayerService, useExisting: ObservationLayerService, multi: true },
-  { provide: DataLayerService, useExisting: MedicationLayerService, multi: true}
+  { provide: DataLayerService, useExisting: MedicationLayerService, multi: true },
 ];

--- a/projects/showcase/src/app/providers/mapper-providers.ts
+++ b/projects/showcase/src/app/providers/mapper-providers.ts
@@ -9,5 +9,5 @@ export const mapperProviders = [
   { provide: Mapper, useExisting: BloodPressureMapper, multi: true },
   { provide: Mapper, useExisting: ComponentObservationMapper, multi: true },
   { provide: Mapper, useExisting: SimpleObservationMapper, multi: true },
-  { provide: Mapper, useExisting : SimpleMedicationMapper, multi: true}
+  { provide: Mapper, useExisting: SimpleMedicationMapper, multi: true },
 ];


### PR DESCRIPTION
## Overview

- Changes the Showcase app to use a Logica Sandbox open API endpoint that I created for this project.
- Changes all code to support FHIR R4 instead of DSTU2:
  - `Observation` can have multiple categories
  - `MedicationOrder` -> `MedicationRequest`
  - `dateWritten` -> `authoredOn`

## How it was tested

- Tested with 3 different patients that I imported into the Logica Sandbox.
- Added some Observations and Medications to the chart
- Ran unit tests

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [x] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
