### PR TITLE
RT-554:Summary card title is too long

### DIFF
--- a/projects/ngx-charts-on-fhir/src/lib/analysis-cards/analysis-card/analysis-card.component.css
+++ b/projects/ngx-charts-on-fhir/src/lib/analysis-cards/analysis-card/analysis-card.component.css
@@ -7,4 +7,8 @@
 }
 .mat-card-title {
   font-size: 20px;
+  max-width: 250px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/projects/ngx-charts-on-fhir/src/lib/analysis-cards/analysis-card/analysis-card.component.css
+++ b/projects/ngx-charts-on-fhir/src/lib/analysis-cards/analysis-card/analysis-card.component.css
@@ -7,7 +7,7 @@
 }
 .mat-card-title {
   font-size: 20px;
-  max-width: 250px;
+  max-width: 350px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/projects/ngx-charts-on-fhir/src/lib/analysis-cards/analysis-card/analysis-card.component.html
+++ b/projects/ngx-charts-on-fhir/src/lib/analysis-cards/analysis-card/analysis-card.component.html
@@ -2,7 +2,7 @@
   <mat-card-title-group>
     <mat-icon class="analysis-card-icon" [style.color]="color">{{ icon }}</mat-icon>
     <mat-card-subtitle *ngIf="subtitle" class="analysis-card-subtitle">{{ subtitle }}</mat-card-subtitle>
-    <mat-card-title *ngIf="title" class="analysis-card-title">{{ title }}</mat-card-title>
+    <mat-card-title *ngIf="title" class="analysis-card-title"  [matTooltip]="title">{{ title }}</mat-card-title>
   </mat-card-title-group>
   <mat-card-content>
     <ng-content></ng-content>

--- a/projects/ngx-charts-on-fhir/src/lib/analysis-cards/analysis-cards.module.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/analysis-cards/analysis-cards.module.ts
@@ -6,10 +6,11 @@ import { MatTableModule } from '@angular/material/table';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { AnalysisCardComponent } from './analysis-card/analysis-card.component';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @NgModule({
   declarations: [AnalysisCardComponent, StatisticsComponent],
-  imports: [CommonModule, MatCardModule, MatTableModule, MatButtonModule, MatIconModule],
+  imports: [CommonModule, MatCardModule, MatTableModule, MatButtonModule, MatIconModule,MatTooltipModule],
   exports: [AnalysisCardComponent, StatisticsComponent],
 })
 export class AnalysisCardsModule {}

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-list/data-layer-list.module.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-list/data-layer-list.module.ts
@@ -17,6 +17,7 @@ import { ColorPickerModule } from '../color-picker/color-picker.module';
 import { MatInputModule } from '@angular/material/input';
 import { AnnotationOptionsComponent } from './annotation-options/annotation-options.component';
 import { AnnotationListComponent } from './annotation-list/annotation-list.component';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @NgModule({
   declarations: [
@@ -40,6 +41,7 @@ import { AnnotationListComponent } from './annotation-list/annotation-list.compo
     MatFormFieldModule,
     ColorPickerModule,
     MatInputModule,
+    MatTooltipModule
   ],
   exports: [DataLayerListComponent],
 })

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-list/data-layer-list/data-layer-list.component.css
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-list/data-layer-list/data-layer-list.component.css
@@ -26,5 +26,5 @@ mat-title{
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 471px;
+  max-width: 450px;
 }

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-list/data-layer-list/data-layer-list.component.css
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-list/data-layer-list/data-layer-list.component.css
@@ -21,3 +21,10 @@
 mat-checkbox {
   margin-right: 8px;
 }
+
+mat-title{
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 471px;
+}

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-list/data-layer-list/data-layer-list.component.html
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-list/data-layer-list/data-layer-list.component.html
@@ -28,7 +28,9 @@
             color="primary"
           >
           </mat-checkbox>
-          {{ layer.name }}
+          <mat-title [matTooltip]="layer.name">
+            {{ layer.name }}
+          </mat-title>
         </mat-panel-title>
       </mat-expansion-panel-header>
       <data-layer-options [layer]="layer" (layerChange)="onLayerChange($event)"></data-layer-options>

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-list/dataset-list/dataset-list.component.css
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-list/dataset-list/dataset-list.component.css
@@ -9,3 +9,8 @@ mat-panel-title {
 mat-checkbox {
   margin-right: 8px;
 }
+mat-title{
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 370px;
+}

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-list/dataset-list/dataset-list.component.css
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-list/dataset-list/dataset-list.component.css
@@ -12,5 +12,5 @@ mat-checkbox {
 mat-title{
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 370px;
+  max-width: 300px;
 }

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-list/dataset-list/dataset-list.component.html
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-list/dataset-list/dataset-list.component.html
@@ -10,7 +10,9 @@
             [title]="dataset.hidden ? 'Show this dataset on the chart' : 'Hide this dataset on the chart'"
             color="primary"
           ></mat-checkbox>
-          {{ dataset.label }}
+          <mat-title matTooltip={{dataset.label}}>
+            {{ dataset.label }}
+          </mat-title>
         </mat-panel-title>
         <mat-panel-description> {{ dataset.data.length }} observations </mat-panel-description>
       </mat-expansion-panel-header>

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-list/dataset-list/dataset-list.component.html
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-list/dataset-list/dataset-list.component.html
@@ -10,7 +10,7 @@
             [title]="dataset.hidden ? 'Show this dataset on the chart' : 'Hide this dataset on the chart'"
             color="primary"
           ></mat-checkbox>
-          <mat-title matTooltip={{dataset.label}}>
+          <mat-title *ngIf="dataset.label" [matTooltip]="dataset.label">
             {{ dataset.label }}
           </mat-title>
         </mat-panel-title>


### PR DESCRIPTION
## Overview

Add ellipses on the Dataset Label, and layer name.
Also, Add a hover tooltip on the dataset label, layer name, and summary card title.

## How it was tested

Tested using run showcase app locally.

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
