### PR TITLE
Use fixed scale bounds

### DIFF
--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.ts
@@ -59,6 +59,9 @@ export class FhirChartComponent implements OnInit {
     // prevents the tick labels of stacked charts from overlapping
     Chart.defaults.scales.linear.offset = true;
 
+    // don't display min/max as extra ticks
+    Chart.defaults.scales.linear.ticks.includeBounds = false;
+
     // disable some distracting animations
     Chart.defaults.plugins.tooltip.animation.duration = 0;
     Chart.defaults.plugins.annotation.animations = {


### PR DESCRIPTION
## Overview

- Set the min/max for each scale based on the min/max values of the datasets and annotations.
- This prevents the scale ticks from changing when zooming/panning the chart.

## How it was tested

- Ran showcase app with mock FHIR server
- Added many different layers (observations and medications)
- Verified that all datapoints and annotations are visible
- Zoomed and panned to check that scale bounds do not change

## Checklist

- [x] The title contains a short meaningful summary
- [ ] I have added a link to this PR in the Jira issue
- [ ] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)
