### PR TITLE
Offset medication gridlines

### DIFF
--- a/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/fhir-mapper-options.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/fhir-mapper-options.ts
@@ -47,8 +47,11 @@ const defaultMedicationScaleOptions: ScaleOptions<'medication'> = {
   ticks: {
     autoSkip: false,
     mirror: true,
-    labelOffset: -20,
+    labelOffset: -17,
   },
+  grid: {
+    offset: true
+  }
 } as const;
 
 export const ANNOTATION_OPTIONS = new InjectionToken<ChartAnnotation>('Annotation Options', {


### PR DESCRIPTION
## Overview

- Offset medication gridlines so they show in between bars instead of centered
- Move medication labels slightly closer to the bars

## How it was tested

- Ran showcase app

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [x] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)
