### PR TITLE
Add default theme with increased density

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -55,7 +55,7 @@
             "tsConfig": "projects/showcase/tsconfig.app.json",
             "inlineStyleLanguage": "scss",
             "assets": ["projects/showcase/src/favicon.ico", "projects/showcase/src/assets", "projects/showcase/src/launch.html"],
-            "styles": ["./node_modules/@angular/material/prebuilt-themes/indigo-pink.css", "projects/showcase/src/styles.scss"],
+            "styles": ["./dist/ngx-charts-on-fhir/themes/default.scss", "projects/showcase/src/styles.scss"],
             "scripts": [
               {
                 "input": "node_modules/fhirclient/build/fhir-client.js",
@@ -146,7 +146,7 @@
             "karmaConfig": "projects/showcase/karma.conf.js",
             "inlineStyleLanguage": "scss",
             "assets": ["projects/showcase/src/favicon.ico", "projects/showcase/src/assets"],
-            "styles": ["./node_modules/@angular/material/prebuilt-themes/indigo-pink.css", "projects/showcase/src/styles.scss"],
+            "styles": ["./dist/ngx-charts-on-fhir/themes/default.scss", "projects/showcase/src/styles.scss"],
             "scripts": []
           }
         }

--- a/projects/ngx-charts-on-fhir/ng-package.json
+++ b/projects/ngx-charts-on-fhir/ng-package.json
@@ -3,5 +3,6 @@
   "dest": "../../dist/ngx-charts-on-fhir",
   "lib": {
     "entryFile": "src/public-api.ts"
-  }
+  },
+  "assets": [{ "input": "src", "glob": "**/*.scss", "output": "themes" }]
 }

--- a/projects/ngx-charts-on-fhir/package.json
+++ b/projects/ngx-charts-on-fhir/package.json
@@ -1,6 +1,11 @@
 {
   "name": "ngx-charts-on-fhir",
   "version": "0.0.1",
+  "exports": {
+    "./themes/default.scss": {
+      "sass": "./themes/default.scss"
+    }
+  },
   "peerDependencies": {
     "@angular/common": "^15.1.0",
     "@angular/core": "^15.1.0"

--- a/projects/ngx-charts-on-fhir/src/default.scss
+++ b/projects/ngx-charts-on-fhir/src/default.scss
@@ -1,5 +1,5 @@
 @use '@angular/material' as mat;
-@use './lib/data-layer-toolbar/data-layer-toolbar/data-layer-toolbar-theme' as toolbar;
+@use './lib/data-layer-toolbar/data-layer-toolbar-theme' as toolbar;
 
 @include mat.core();
 

--- a/projects/ngx-charts-on-fhir/src/default.scss
+++ b/projects/ngx-charts-on-fhir/src/default.scss
@@ -1,0 +1,28 @@
+@use '@angular/material' as mat;
+@use './lib/data-layer-toolbar/data-layer-toolbar/data-layer-toolbar-theme' as toolbar;
+
+@include mat.core();
+
+// Define a theme.
+$primary: mat.define-palette(mat.$indigo-palette);
+$accent:  mat.define-palette(mat.$pink-palette, A200, A100, A400);
+
+$theme: mat.define-light-theme((
+  color: (
+    primary: $primary,
+    accent: $accent
+  ),
+  typography: mat.define-typography-config(),
+  density: -1,
+));
+@include mat.typography-hierarchy($theme);
+
+// Apply theme to all @angular/material components
+@include mat.all-component-themes($theme);
+
+// Apply theme to ngx-charts-on-fhir components
+@include toolbar.theme($theme);
+
+// Adjust density for some components
+@include mat.table-density('minimum');
+@include mat.button-toggle-density(0);

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-browser/data-layer-browser.component.css
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-browser/data-layer-browser.component.css
@@ -9,6 +9,9 @@
   padding-left: 20px;
   padding-right: 20px;
 }
+.filter {
+  width: 400px;
+}
 .scroll-container {
   flex: 1 1 auto;
   overflow-y: auto;
@@ -22,10 +25,16 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.mat-column-datapoints,
-.mat-column-add {
+.mat-column-category {
+  width: 100px;
+}
+.mat-column-datapoints {
+  width: 48px;
   text-align: end;
-  justify-content: flex-end;
+}
+.mat-column-add {
+  text-align: center;
+  width: 48px;
 }
 .empty-message {
   padding: 16px;

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-browser/data-layer-browser.component.html
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-browser/data-layer-browser.component.html
@@ -1,7 +1,7 @@
 <div class="browser-container">
   <header class="controls">
     <h2>Available Data Layers</h2>
-    <mat-form-field class="filter" appearance="outline">
+    <mat-form-field class="filter">
       <mat-icon matPrefix fontIcon="search"></mat-icon>
       <input matInput [formControl]="filterControl" placeholder="Search" />
       <button mat-icon-button matSuffix (click)="filterControl.setValue('')"><mat-icon fontIcon="close"></mat-icon></button>
@@ -12,7 +12,7 @@
   </section>
 
   <div class="scroll-container">
-    <table mat-table [dataSource]="dataSource" [trackBy]="getLayerId" class="data-layer-table" matSort aria-label="Available data layers">
+    <table mat-table [dataSource]="dataSource" [trackBy]="getLayerId" class="data-layer-table" matSort matSortActive="name" matSortDirection="asc" aria-label="Available data layers">
       <ng-container matColumnDef="name">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>Name</th>
         <td mat-cell *matCellDef="let layer" class="ellipsis">{{ layer.name }}</td>
@@ -26,9 +26,9 @@
         <td mat-cell *matCellDef="let layer">{{ getDatapointCount(layer) }}</td>
       </ng-container>
       <ng-container matColumnDef="add">
-        <th mat-header-cell *matHeaderCellDef></th>
+        <th mat-header-cell *matHeaderCellDef>Add</th>
         <td mat-cell *matCellDef="let layer">
-          <button mat-mini-fab color="primary" (click)="layerManager.select(layer.id)"><mat-icon fontIcon="add"></mat-icon></button>
+          <button mat-icon-button color="primary" (click)="layerManager.select(layer.id)"><mat-icon fontIcon="add_circle"></mat-icon></button>
         </td>
       </ng-container>
 

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-browser/data-layer-browser.component.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-browser/data-layer-browser.component.ts
@@ -17,7 +17,7 @@ export class DataLayerBrowserComponent implements OnInit, AfterViewInit {
   constructor(readonly layerManager: DataLayerManagerService) {}
 
   dataSource = new MatTableDataSource<DataLayer>();
-  displayedColumns = ['name', 'category', 'datapoints', 'add'];
+  displayedColumns = ['add', 'name', 'category', 'datapoints'];
   filterControl = new FormControl('');
 
   @ViewChild(MatSort) sort?: MatSort;

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-list/data-layer-list/data-layer-list.component.html
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-list/data-layer-list/data-layer-list.component.html
@@ -35,7 +35,7 @@
       </mat-expansion-panel-header>
       <data-layer-options [layer]="layer" (layerChange)="onLayerChange($event)"></data-layer-options>
       <mat-action-row>
-        <button mat-mini-fab color="primary" (click)="onLayerRemove(layer)" title="Remove this layer"><mat-icon fontIcon="delete"></mat-icon></button>
+        <button mat-button color="primary" (click)="onLayerRemove(layer)" title="Remove this layer"><mat-icon fontIcon="delete"></mat-icon> REMOVE LAYER</button>
       </mat-action-row>
     </mat-expansion-panel>
   </mat-accordion>

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-list/dataset-options/dataset-options.component.css
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-list/dataset-options/dataset-options.component.css
@@ -8,8 +8,10 @@ section h3 {
   margin-top: 8px;
   margin-bottom: 8px;
 }
-
-mat-form-field,
+mat-form-field {
+  display: block;
+}
 mat-slide-toggle {
   display: block;
+  margin: 16px 4px;
 }

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-toolbar/_data-layer-toolbar-theme.scss
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-toolbar/_data-layer-toolbar-theme.scss
@@ -1,0 +1,11 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+
+@mixin theme($theme) {
+  $color-config: mat.get-color-config($theme);
+  $primary-palette: map.get($color-config, 'primary');
+
+  .layout-toolbar {
+    background-color: mat.get-color-from-palette($primary-palette, 500);
+  }
+}

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-toolbar/data-layer-toolbar-button/data-layer-toolbar-button.component.css
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-toolbar/data-layer-toolbar-button/data-layer-toolbar-button.component.css
@@ -1,6 +1,6 @@
 .button-wrapper {
   text-align: center;
-  color: #bfc9ff;
+  color: #ffffffbb;
   border-left: 3px solid transparent;
   padding-right: 3px;
   margin-top: 8px;

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-toolbar/data-layer-toolbar/data-layer-toolbar.component.css
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-toolbar/data-layer-toolbar/data-layer-toolbar.component.css
@@ -1,6 +1,5 @@
 .layout-toolbar {
   color: #fff;
-  background-color: #3f51b5;
   position: absolute;
   height: 100vh;
   width: 54px;

--- a/projects/ngx-charts-on-fhir/src/lib/dynamic-table/dynamic-table.component.css
+++ b/projects/ngx-charts-on-fhir/src/lib/dynamic-table/dynamic-table.component.css
@@ -2,8 +2,8 @@ table {
   width: 100%;
 }
 
-td.mat-cell,
-th.mat-header-cell {
+td.mat-mdc-cell,
+th.mat-mdc-header-cell {
   text-align: end;
   justify-content: flex-end;
   white-space: nowrap;
@@ -11,8 +11,8 @@ th.mat-header-cell {
   padding-left: 8px;
 }
 
-td.mat-cell:first-child,
-th.mat-header-cell:first-child {
+td.mat-mdc-cell:first-child,
+th.mat-mdc-header-cell:first-child {
   text-align: left;
   justify-content: flex-start;
 }


### PR DESCRIPTION
## Overview

- ngx-charts-on-fhir exports a `default.scss` material theme with increased density settings
- showcase app loads the theme in angular.json styles array
- applied the theme color to data-layer-toolbar component instead of using hardcoded indigo color
- replaced mini-fab buttons with smaller icon buttons in data-layer-browser (add) and data-layer-list (delete)
- improved data-layer-browser layout
- fixed some things from the material mdc migration and other minor style issues

## How it was tested

- Ran showcase app with mock FHIR server

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [x] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
