### PR TITLE
Add deployment to build-test workflow

### DIFF
--- a/.github/workflows/build-test.js.yml
+++ b/.github/workflows/build-test.js.yml
@@ -49,3 +49,14 @@ jobs:
           -Dsonar.coverage.exclusions=**/*.spec.ts,**/test.ts,**/main.ts,**/polyfills.ts,**/*.module.ts,**/environment*.ts,**/*.js
           -Dsonar.test.inclusions=**/*.spec.ts,**/test.ts
           
+  deploy:
+    if: ${{ github.ref == 'refs/heads/main' }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Deploy
+      uses: fjogeleit/http-request-action@v1
+      with:
+        url: ${{ secrets.DEPLOY_HOOK_URL }}
+        method: 'POST'
+        


### PR DESCRIPTION
## Overview

- Adds deploy job to build-test workflow
- deploy job only runs for main branch
- deploy job only runs after successful build/test/scan

## How it was tested

- Tested that deployment is skipped for feature branches by checking the workflow results on this PR
- Cannot test deployment on main until this is merged

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)
