### PR TITLE
RT-606-matNoDataRow-colspan

### DIFF
--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-browser/data-layer-browser.component.html
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-browser/data-layer-browser.component.html
@@ -12,7 +12,16 @@
   </section>
 
   <div class="scroll-container">
-    <table mat-table [dataSource]="dataSource" [trackBy]="getLayerId" class="data-layer-table" matSort matSortActive="name" matSortDirection="asc" aria-label="Available data layers">
+    <table
+      mat-table
+      [dataSource]="dataSource"
+      [trackBy]="getLayerId"
+      class="data-layer-table"
+      matSort
+      matSortActive="name"
+      matSortDirection="asc"
+      aria-label="Available data layers"
+    >
       <ng-container matColumnDef="name">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>Name</th>
         <td mat-cell *matCellDef="let layer" class="ellipsis">{{ layer.name }}</td>
@@ -35,14 +44,14 @@
       <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>
       <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
       <tr *matNoDataRow>
-        <td *ngIf="filterControl.value">
+        <td *ngIf="filterControl.value" [attr.colspan]="3">
           <p class="empty-message">No data layers match the filter.</p>
           <button mat-button color="primary" (click)="filterControl.setValue('')">SHOW ALL</button>
         </td>
-        <td *ngIf="!filterControl.value && (layerManager.selectedLayers$ | async)?.length">
+        <td *ngIf="!filterControl.value && (layerManager.selectedLayers$ | async)?.length" [attr.colspan]="3">
           <p class="empty-message">All data layers have already been added to the chart.</p>
         </td>
-        <td *ngIf="!filterControl.value && !(layerManager.selectedLayers$ | async)?.length">
+        <td *ngIf="!filterControl.value && !(layerManager.selectedLayers$ | async)?.length" [attr.colspan]="3">
           <p class="empty-message">No data layers are available for this patient.</p>
         </td>
       </tr>


### PR DESCRIPTION
## Overview
Added colspan to display empty messages properly
![image](https://user-images.githubusercontent.com/57406228/214571594-35601d4b-d4d6-460d-96ec-e3d97755092e.png)

![image](https://user-images.githubusercontent.com/57406228/214572155-ec0d83cc-5a19-4d78-90e1-582f6e47b14d.png)


## How it was tested
Tested by launching the charts-on-fhir locally, In the browser layer selected all layers and also search for layers that are not present in all layers. The empty message is showing properly after this change. Added The screenshot after colspan change. 


## Checklist

- [X] The title contains a short meaningful summary
- [X] I have added a link to this PR in the Jira issue
- [X] I have described how this was tested
- [X] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [X] I have run unit tests locally
- [ ] I have updated documentation (including README)
