### PR TITLE
Add glucose code 2339-0

### DIFF
--- a/projects/cardiovascular-health/src/app/datasets/observations.service.ts
+++ b/projects/cardiovascular-health/src/app/datasets/observations.service.ts
@@ -41,6 +41,11 @@ export class ObservationLayerService extends DataLayerService {
     },
     {
       system: 'http://loinc.org',
+      code: '2339-0',
+      display: 'Glucose',
+    },
+    {
+      system: 'http://loinc.org',
       code: '59408-5',
       display: 'Oxygen saturation in Arterial blood by Pulse oximetry',
     },


### PR DESCRIPTION
## Overview

- Added LOINC code 2339-0 to cardio app's observations service so Synthea's Glucose measurements will show up in the app.

## How it was tested

- Ran cardio app locally using a Patient with Glucose observations coded as 2339-0
- Checked that the Glucose graph is displayed

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)
