### PR TITLE
RT-632-BP-Range:Default BP Reference Range

### DIFF
--- a/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/blood-pressure-mapper.service.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/blood-pressure-mapper.service.ts
@@ -37,14 +37,14 @@ export class BloodPressureMapper implements Mapper<BloodPressureObservation> {
         display: true,
         label: { content: 'Systolic Blood Pressure Reference Range' },
         yScaleID: layer.datasets[0].yAxisID,
-        yMax: 130,
+        yMax: 140,
         yMin: 90,
       }),
       merge({}, this.annotationOptions, {
         display: true,
         label: { content: 'Diastolic Blood Pressure Reference Range' },
         yScaleID: layer.datasets[0].yAxisID,
-        yMax: 80,
+        yMax: 90,
         yMin: 60,
       }),
     ];


### PR DESCRIPTION
## Overview
Change Systolic yMax value from 130 to 140 and diastolic yMax from 80 to 90.

![image](https://user-images.githubusercontent.com/117890382/216572815-6cd02369-7122-4f63-a9ff-b3f2f400c15f.png)

## How it was tested
Tested Using run showcase app locally.

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [x] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
