### PR TITLE
Default styles for home measurements

### DIFF
--- a/projects/ngx-charts-on-fhir/src/lib/data-layer/data-layer-color.service.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer/data-layer-color.service.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable, InjectionToken } from '@angular/core';
 import { DataLayer, Dataset } from './data-layer';
 import tinycolor from 'tinycolor2';
+import { BoxAnnotationOptions } from 'chartjs-plugin-annotation';
 
 export const COLOR_PALETTE = new InjectionToken<string[]>('Color Palette');
 
@@ -22,6 +23,33 @@ export class DataLayerColorService {
         const color = this.palette[this.nextColorIndex];
         this.nextColorIndex = (this.nextColorIndex + 1) % this.palette.length;
         this.setColor(dataset, color);
+        this.setMatchingAnnotationColor(layer, dataset);
+        this.setMatchingDatasetColor(layer, dataset);
+      }
+    }
+  }
+
+  /** Finds the corresponding annotations for a dataset and changes their colors to match the dataset */
+  private setMatchingAnnotationColor(layer: DataLayer, dataset: Dataset) {
+    if (layer.annotations && dataset.label) {
+      for (let annotation of layer.annotations) {
+        const anno = annotation as BoxAnnotationOptions;
+        const label = anno.label?.content;
+        if (typeof label === 'string' && label.startsWith(dataset.label)) {
+          anno.backgroundColor = this.addTransparency(this.getColor(dataset));
+        }
+      }
+    }
+  }
+
+  /** Finds associated datasets and changes their colors to match the given dataset */
+  private setMatchingDatasetColor(layer: DataLayer, dataset: Dataset) {
+    if (dataset.label) {
+      for (let other of layer.datasets) {
+        if (other !== dataset && other.label?.startsWith(dataset.label)) {
+          const color = tinycolor(this.getColor(dataset));
+          this.setColor(other, color.brighten(20).toString());
+        }
       }
     }
   }

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/medication-request/duration-medication-mapper.service.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/medication-request/duration-medication-mapper.service.ts
@@ -203,7 +203,7 @@ export class DurationMedicationMapper implements Mapper<DurationMedication> {
     const layer = this.baseMapper.map(resource) as DataLayer<'line', MedicationDataPoint[]>;
     layer.datasets = layer.datasets.map((dataset) => ({
       ...dataset,
-      label: dataset.label + ' (duration)',
+      label: dataset.label + ' *',
       type: 'line',
       pointRadius: 0,
       pointHoverRadius: 0,

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/component-observation-mapper.service.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/component-observation-mapper.service.ts
@@ -6,7 +6,7 @@ import { DataLayer } from '../../data-layer/data-layer';
 import { Mapper } from '../multi-mapper.service';
 import { ChartAnnotation, isDefined } from '../../utils';
 import { TIME_SCALE_OPTIONS, LINEAR_SCALE_OPTIONS, ANNOTATION_OPTIONS } from '../fhir-mapper-options';
-import { getMeasurementSettingSuffix } from './simple-observation-mapper.service';
+import { getMeasurementSettingSuffix, isHomeMeasurement } from './simple-observation-mapper.service';
 
 /** Required properties for mapping an Observation with [ComponentObservationMapper] */
 export type ComponentObservation = {
@@ -61,6 +61,8 @@ export class ComponentObservationMapper implements Mapper<ComponentObservation> 
         .map((component) => ({
           label: component.code.text + getMeasurementSettingSuffix(resource),
           yAxisID: scaleName,
+          pointRadius: isHomeMeasurement(resource) ? 3 : 5,
+          pointStyle: isHomeMeasurement(resource) ? 'rectRot' : 'circle',
           data: [
             {
               x: new Date(resource.effectiveDateTime).getTime(),

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/simple-observation-mapper.service.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/simple-observation-mapper.service.ts
@@ -49,6 +49,8 @@ export class SimpleObservationMapper implements Mapper<SimpleObservation> {
         {
           label: resource.code.text + getMeasurementSettingSuffix(resource),
           yAxisID: scaleName,
+          pointRadius: isHomeMeasurement(resource) ? 3 : 5,
+          pointStyle: isHomeMeasurement(resource) ? 'rectRot' : 'circle',
           data: [
             {
               x: new Date(resource.effectiveDateTime).getTime(),
@@ -76,11 +78,14 @@ export class SimpleObservationMapper implements Mapper<SimpleObservation> {
 export const measurementSettingExtUrl = 'http://hl7.org/fhir/us/vitals/StructureDefinition/MeasurementSettingExt';
 export const homeEnvironmentCode = '264362003';
 export function getMeasurementSettingSuffix(resource: Observation): string {
+  return isHomeMeasurement(resource) ? HOME_DATASET_LABEL_SUFFIX : '';
+}
+export function isHomeMeasurement(resource: Observation): boolean {
   if (resource.meta?.extension) {
     const measurementSetting = resource.meta.extension.find((ext) => ext.url === measurementSettingExtUrl);
     if (measurementSetting?.valueCodeableConcept?.coding?.[0].code === homeEnvironmentCode) {
-      return HOME_DATASET_LABEL_SUFFIX;
+      return true;
     }
   }
-  return '';
+  return false;
 }


### PR DESCRIPTION
## Overview

- Sets a different point style/radius for home measurements
- Matches dataset and annotation colors by default

## How it was tested

- Ran showcase app with home measurement data
- Tested that both home and office points display correctly
- Tested manually changing options as well

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [x] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)
