### PR TITLE
Fix measurement setting extension

### DIFF
--- a/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/simple-observation-mapper.service.spec.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/simple-observation-mapper.service.spec.ts
@@ -115,20 +115,17 @@ describe('SimpleObservationMapper', () => {
         code: { text: 'text' },
         effectiveDateTime: new Date().toISOString(),
         valueQuantity: { value: 7, unit: 'unit' },
-        meta: {
-          extension: [
-            {
-              url: measurementSettingExtUrl,
-              valueCodeableConcept: {
-                coding: [{ code: homeEnvironmentCode }],
-              },
+        extension: [
+          {
+            url: measurementSettingExtUrl,
+            valueCodeableConcept: {
+              coding: [{ code: homeEnvironmentCode }],
             },
-          ],
-        },
+          },
+        ],
       };
       const mapper = new SimpleObservationMapper({}, {}, {});
       expect(mapper.map(observation).datasets[0].label).toBe('text' + HOME_DATASET_LABEL_SUFFIX);
     });
-
   });
 });

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/simple-observation-mapper.service.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/simple-observation-mapper.service.ts
@@ -81,8 +81,8 @@ export function getMeasurementSettingSuffix(resource: Observation): string {
   return isHomeMeasurement(resource) ? HOME_DATASET_LABEL_SUFFIX : '';
 }
 export function isHomeMeasurement(resource: Observation): boolean {
-  if (resource.meta?.extension) {
-    const measurementSetting = resource.meta.extension.find((ext) => ext.url === measurementSettingExtUrl);
+  if (resource.extension) {
+    const measurementSetting = resource.extension.find((ext) => ext.url === measurementSettingExtUrl);
     if (measurementSetting?.valueCodeableConcept?.coding?.[0].code === homeEnvironmentCode) {
       return true;
     }

--- a/projects/synthea-utils/index.ts
+++ b/projects/synthea-utils/index.ts
@@ -85,16 +85,15 @@ async function savePatientBundle(patientName: string, bundle: Bundle) {
   await fs.writeFile(filepath, JSON.stringify(bundle, null, 2));
 }
 
-/** Add Measurement Setting extension to Observations with an associated "Encounter by computer link" */
+/** Add Measurement Setting extension to Home Observations */
 function addMeasurementSetting(bundle: Bundle) {
   console.log('Adding Measurement Setting Extension');
   for (let entry of bundle.entry) {
     if (entry.resource.resourceType === 'Observation' && entry.resource.code.text.endsWith(HOME_DATASET_LABEL_SUFFIX)) {
       entry.resource.code.text = trimSuffix(entry.resource.code.text, HOME_DATASET_LABEL_SUFFIX);
       entry.resource.code.coding[0].display = trimSuffix(entry.resource.code.coding[0].display, HOME_DATASET_LABEL_SUFFIX);
-      entry.resource.meta = entry.resource.meta ?? {};
-      entry.resource.meta.extension = entry.resource.meta.extension ?? [];
-      entry.resource.meta.extension.push(HOME_ENVIRONMENT);
+      entry.resource.extension = entry.resource.extension ?? [];
+      entry.resource.extension.push(HOME_ENVIRONMENT);
     }
   }
 }


### PR DESCRIPTION
## Overview

- Fixed location of measurement setting extension (`resource.extension` instead of `resource.meta.extension`) in synthea-utils script and observation mapper.

## How it was tested

- Generated a patient with synthea-utils
- Checked the FHIR JSON bundle to make sure extension was correct
- Uploaded patient bundle to Logica
- Ran showcase app with Logica open FHIR server
- Checked that home/office measurements are displayed correctly

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [x] I have included screen shots for changes that affect the user interface
- [x] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
