### PR TITLE
Color service fixes

### DIFF
--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-list/dataset-options/dataset-options.component.spec.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-list/dataset-options/dataset-options.component.spec.ts
@@ -14,11 +14,6 @@ import { COLOR_PALETTE, DataLayerColorService } from '../../data-layer/data-laye
 import { DatasetOptionsComponent } from './dataset-options.component';
 import { Chart } from 'chart.js';
 
-const mockColorService = {
-  getColor: () => '#000000',
-  setColor: () => {},
-};
-
 @Component({
   selector: 'color-picker',
   template: '',
@@ -35,8 +30,10 @@ describe('DatasetOptionsComponent', () => {
   let component: DatasetOptionsComponent;
   let fixture: ComponentFixture<DatasetOptionsComponent>;
   let loader: HarnessLoader;
+  let mockColorService: jasmine.SpyObj<DataLayerColorService>;
 
   beforeEach(async () => {
+    mockColorService = jasmine.createSpyObj('DataLayerColorService', ['getColor','setColor']);
     await TestBed.configureTestingModule({
       declarations: [DatasetOptionsComponent, MockColorPickerComponent],
       imports: [MatButtonModule, MatButtonToggleModule, MatSlideToggleModule, MatSliderModule, MatIconModule, ReactiveFormsModule],
@@ -96,4 +93,9 @@ describe('DatasetOptionsComponent', () => {
     expect(await pointRadius.getValue()).toEqual(3);
   }));
 
+  it('should not set dataset color to empty string', () => {
+    component.dataset = { label: 'Dataset', data: [] };
+    component.form.controls.color.setValue('');
+    expect(mockColorService.setColor).not.toHaveBeenCalled();
+  });
 });

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer-list/dataset-options/dataset-options.component.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer-list/dataset-options/dataset-options.component.ts
@@ -52,7 +52,9 @@ export class DatasetOptionsComponent implements OnInit {
       this.datasetChange.emit(
         produce(this._dataset, (draft) => {
           merge(draft, props);
-          this.colorService.setColor(draft, formValue.color ?? '');
+          if (formValue.color) {
+            this.colorService.setColor(draft, formValue.color ?? '');
+          }
         })
       );
     }

--- a/projects/ngx-charts-on-fhir/src/lib/data-layer/data-layer-color.service.spec.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/data-layer/data-layer-color.service.spec.ts
@@ -16,15 +16,43 @@ describe('DataLayerColorService', () => {
   });
 
   describe('chooseColorsFromPalette', () => {
-    it('should call setColor', inject([DataLayerColorService], (service: DataLayerColorService) => {
+    it('should cycle through the palette', inject([DataLayerColorService], (service: DataLayerColorService) => {
       const layer: any = {
-        datasets: [{ label: 'Diastolic Blood Pressure' }],
+        datasets: [{ label: 'One' }, { label: 'Two' }, { label: 'Three'}],
         annotations: [{ label: { display: true } }],
-        backgroundColor: '#ECF0F9',
       };
-      let setColorSpy = spyOn(service, 'setColor');
       service.chooseColorsFromPalette(layer);
-      expect(setColorSpy).toHaveBeenCalled();
+      expect(layer.datasets[0].borderColor).toEqual(palette[0]);
+      expect(layer.datasets[1].borderColor).toEqual(palette[1]);
+      expect(layer.datasets[2].borderColor).toEqual(palette[0]);
+    }));
+
+    it('should reuse color from matching dataset', inject([DataLayerColorService], (service: DataLayerColorService) => {
+      const layer: any = {
+        datasets: [{ label: 'One' }, { label: 'One (X)' }],
+        annotations: [{ label: { display: true } }],
+      };
+      service.chooseColorsFromPalette(layer);
+      expect(layer.datasets[0].borderColor).toEqual(palette[0]);
+      expect(layer.datasets[1].borderColor).toEqual(palette[0]);
+    }));
+
+    it('should brighten palette color by 20% for home measurements', inject([DataLayerColorService], (service: DataLayerColorService) => {
+      const layer: any = {
+        datasets: [{ label: 'One (Home)' }],
+        annotations: [{ label: { display: true } }],
+      };
+      service.chooseColorsFromPalette(layer);
+      expect(layer.datasets[0].borderColor).toEqual('#333333');
+    }));
+
+    it('should add transparency for matching annotation color', inject([DataLayerColorService], (service: DataLayerColorService) => {
+      const layer: any = {
+        datasets: [{ label: 'One' }],
+        annotations: [{ label: { display: true, content: 'One Annotation' } }],
+      };
+      service.chooseColorsFromPalette(layer);
+      expect(layer.annotations[0].backgroundColor).toEqual('rgba(0, 0, 0, 0.2)');
     }));
   });
 


### PR DESCRIPTION
## Overview

- `DataLayerMergeService` now calls `colorService.chooseColorsFromPalette()` when adding a new dataset to a selected layer.
- Reworks the `chooseColorsFromPalette` code so it is more robust and works regardless of the order in which datasets are added.
- Fixes a bug in dataset-options component that was setting dataset color to empty string.
- Adds unit tests

## How it was tested

- Ran cardiovascular-health app with Logica Open environment using patient 30049
- Temporarily changed cardio app.component so it calls `layerManager.select()` every time `availableLayers$` emits (I am not committing this change because we are rewriting that code in another PR and don't want conflicts)
- Checked that colors show up correctly while the graph is loading and after it finishes loading.
- Checked that colors show up correctly in the dataset-options component.

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [x] I have included screen shots for changes that affect the user interface
- [x] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
