### PR TITLE
Fix Days Outside Goal is not displayed

### DIFF
--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart-summary/home-measurement-summary.service.spec.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart-summary/home-measurement-summary.service.spec.ts
@@ -82,8 +82,44 @@ describe('HomeMeasurementSummaryService', () => {
           },
         ],
       };
+      const expectedCombinedLayer = {
+        datasets: [
+          {
+            label: 'Test',
+            data: [{ x: 1, y: 1 }],
+          },
+          {
+            label: 'Different',
+            data: [{ x: 2, y: 2 }],
+          },
+        ],
+      } as DataLayer;
       summaryService.summarize(layer as DataLayer, { min: 0, max: 2 });
-      expect(baseSummaryService.summarize).toHaveBeenCalledWith(layer, { min: 0, max: 2 });
+      expect(baseSummaryService.summarize).toHaveBeenCalledWith(expectedCombinedLayer, { min: 0, max: 2 });
+    });
+
+    it('should use original label regardless of dataset order', () => {
+      const layer: any = {
+        datasets: [
+          {
+            label: 'Test' + HOME_DATASET_LABEL_SUFFIX,
+            data: [{ x: 2, y: 2 }],
+          },
+          {
+            label: 'Test',
+            data: [{ x: 1, y: 1 }],
+          },
+        ],
+      };
+      const expectedCombinedLayer: any = {
+        datasets: [
+          jasmine.objectContaining({
+            label: 'Test',
+          }),
+        ],
+      };
+      summaryService.summarize(layer as DataLayer, { min: 0, max: 2 });
+      expect(baseSummaryService.summarize).toHaveBeenCalledWith(expectedCombinedLayer, { min: 0, max: 2 });
     });
   });
 });

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart-summary/home-measurement-summary.service.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart-summary/home-measurement-summary.service.ts
@@ -18,7 +18,7 @@ export class HomeMeasurementSummaryService implements SummaryService {
   }
   summarize(layer: DataLayer, range: NumberRange): Record<string, string>[] {
     const groups = groupBy(layer.datasets, getOriginalLabel);
-    const datasets = Object.values(groups).map((ds) => ({ ...ds[0], data: ds.flatMap(d => d.data) }));
+    const datasets = Object.entries(groups).map(([label, ds]) => ({ ...ds[0], label, data: ds.flatMap(d => d.data) }));
     const combined = { ...layer, datasets };
     return this.baseSummaryService.summarize(combined, range);
   }


### PR DESCRIPTION
## Overview

- Fixes a bug where "Days Outside Goal" is not displayed in the summary panel for datasets with home measurements

## How it was tested

- Ran cardio and showcase apps locally with Logica Open environment, Patient 30049
- Checked that Outside Goal is displayed in the BP summary panel

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [x] I have included screen shots for changes that affect the user interface
- [x] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
