### PR TITLE
RT-659-Refresh-chart:Refresh chart and last-reported after submitting BP

### DIFF
--- a/projects/cardiovascular-patient-app/src/app/app.component.html
+++ b/projects/cardiovascular-patient-app/src/app/app.component.html
@@ -5,7 +5,7 @@
   (selectedIndexChange)="selectedIndex = $event">
   <mat-tab label="Report BP">
     <last-report-bp></last-report-bp>
-    <report-bp (resourceCreated)="selectedIndex = 1"></report-bp>
+    <report-bp (resourceCreated)="getBpLayerdata()"></report-bp>
   </mat-tab>
   <mat-tab label="See prior BPs">
     <div class="layout-main" id="layout-main">

--- a/projects/cardiovascular-patient-app/src/app/app.component.ts
+++ b/projects/cardiovascular-patient-app/src/app/app.component.ts
@@ -22,4 +22,9 @@ export class AppComponent implements OnInit {
       layers.forEach((layer) => this.layerManager.select(layer.id));
     });
   }
+  
+  getBpLayerdata() {
+    this.layerManager.retrieveAll();
+    this.selectedIndex = 1;
+  }
 }


### PR DESCRIPTION
## Overview
For getting Updated BP layer data we call the retrieveAll function.
![image](https://user-images.githubusercontent.com/117890382/222404414-50af05f3-2556-4fc2-8f5a-a244d9a0d651.png)
![image](https://user-images.githubusercontent.com/117890382/222404645-13623eaa-c18d-454d-8462-5d27575d2956.png)
![image](https://user-images.githubusercontent.com/117890382/222405052-25189af0-8a81-4a40-a704-83cc1a688d8e.png)
![image](https://user-images.githubusercontent.com/117890382/222405208-ef95afd6-f8dd-4105-9554-f44272e3f0ce.png)


## How it was tested
Tested using run cardio-patient-app locally.


## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [x] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
