### PR TITLE
RT-663-loading-indicator:Patient app loading indicator

### DIFF
--- a/projects/cardiovascular-patient-app/src/app/last-report-bp/last-report-bp.component.html
+++ b/projects/cardiovascular-patient-app/src/app/last-report-bp/last-report-bp.component.html
@@ -1,8 +1,17 @@
 <mat-card class="card-widget">
   <mat-card-content>
     <div *ngIf="lastReportedBPdata !=null ; else noPriorBp">
-      Last BP reported was {{ lastReportedBPdata.systolic.value }}/{{ lastReportedBPdata.diastolic.value }} on {{formatDate(lastReportedBPdata.systolic.date)}} at {{formatTime(lastReportedBPdata.systolic.date)}}
+      Last BP reported was {{ lastReportedBPdata.systolic.value }}/{{ lastReportedBPdata.diastolic.value }} on
+      {{formatDate(lastReportedBPdata.systolic.date)}} at {{formatTime(lastReportedBPdata.systolic.date)}}
     </div>
-    <ng-template #noPriorBp> There is no last reported prior BP for Patient </ng-template>
+    <ng-template #noPriorBp>
+      <div class="empty-message-content">
+        <ng-container *ngIf="layerManager.loading$ | async; else doneLoading">
+          <div>Loading data...</div>
+          <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+        </ng-container>
+        <ng-template #doneLoading> There is no last reported prior BP for Patient </ng-template>
+      </div>
+    </ng-template>
   </mat-card-content>
 </mat-card>

--- a/projects/cardiovascular-patient-app/src/app/last-report-bp/last-report-bp.component.ts
+++ b/projects/cardiovascular-patient-app/src/app/last-report-bp/last-report-bp.component.ts
@@ -15,7 +15,7 @@ export interface LastReportedBPdata {
 })
 export class LastReportBPComponent {
   lastReportedBPdata?: LastReportedBPdata;
-  constructor(private layerManager: DataLayerManagerService) { }
+  constructor(public layerManager: DataLayerManagerService) { }
 
   ngOnInit(): void {
     this.layerManager.allLayers$

--- a/projects/cardiovascular-patient-app/src/app/last-report-bp/last-report-bp.module.ts
+++ b/projects/cardiovascular-patient-app/src/app/last-report-bp/last-report-bp.module.ts
@@ -2,10 +2,11 @@ import { NgModule } from '@angular/core';
 import { LastReportBPComponent } from './last-report-bp.component';
 import { MatCardModule } from '@angular/material/card';
 import { CommonModule } from '@angular/common';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
 
 @NgModule({
   declarations: [LastReportBPComponent],
-  imports: [MatCardModule,CommonModule],
+  imports: [MatCardModule,CommonModule,MatProgressBarModule],
   exports: [LastReportBPComponent],
 })
 export class LastReportBPModule { }


### PR DESCRIPTION
## Overview
Used the ngIf condition for checking layermanger.loading or not.
A mat-progress-bar  and Loading data text are used to indicate that data is being loaded, and after loading, the message is displayed.
![image](https://user-images.githubusercontent.com/117890382/223128919-6d925de3-d771-4f40-9858-8efab200871d.png)

## How it was tested
Tested Using Run cardio-patient-app locally.


## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [x] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
