### PR TITLE
Set base-href when building docs for github-pages

### DIFF
--- a/.github/workflows/build-test.js.yml
+++ b/.github/workflows/build-test.js.yml
@@ -107,7 +107,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
       - run: npm ci
-      - run: npm run build documentation
+      - run: npm run build documentation -- --base-href=/charts-on-fhir/
       - uses: actions/upload-pages-artifact@main
         with:
           path: dist/documentation


### PR DESCRIPTION
## Overview

- Set base-href to /charts-on-fhir/ when building docs for github-pages

## How it was tested

- Cannot test until it is merged

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [ ] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)
