### PR TITLE
Fix npm publish dir

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,7 +16,6 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build ngx-charts-on-fhir
-      - run: cd dist/ngx-charts-on-fhir
-      - run: npm publish --access public
+      - run: npm publish dist/ngx-charts-on-fhir --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Overview

- Added dir to npm publish command instead of trying to `cd` in a separate step

## How it was tested

- Ran npm publish command locally with --dry-run to make sure it packages the right dir

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [ ] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)
