### PR TITLE
Add trailing slash to npm publish dir

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,6 +16,6 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build ngx-charts-on-fhir
-      - run: npm publish dist/ngx-charts-on-fhir --access public
+      - run: npm publish dist/ngx-charts-on-fhir/ --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Overview

According to [this post](https://github.com/npm/cli/issues/3993), adding a trailing slash should fix this workflow failure.

## How it was tested

- N/A

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [ ] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)
