### PR TITLE
Fix Angular routing in GitHub Pages

### DIFF
--- a/.github/workflows/build-test.js.yml
+++ b/.github/workflows/build-test.js.yml
@@ -89,7 +89,7 @@ jobs:
             -Dsonar.test.inclusions=**/*.spec.ts,**/test.ts
     
   build-docs:
-    # if: ${{ github.ref == 'refs/heads/main' }} # temporarily commented out for testing in PR branch
+    if: ${{ github.ref == 'refs/heads/main' }}
     needs: 
       - build-ngx-charts-on-fhir
       - build-apps

--- a/.github/workflows/build-test.js.yml
+++ b/.github/workflows/build-test.js.yml
@@ -108,6 +108,7 @@ jobs:
           cache: "npm"
       - run: npm ci
       - run: npm run build documentation -- --base-href=/charts-on-fhir/
+      - run: cp dist/documentation/index.html dist/documentation/404.html # Needed for Angular routing
       - uses: actions/upload-pages-artifact@main
         with:
           path: dist/documentation

--- a/.github/workflows/build-test.js.yml
+++ b/.github/workflows/build-test.js.yml
@@ -89,7 +89,7 @@ jobs:
             -Dsonar.test.inclusions=**/*.spec.ts,**/test.ts
     
   build-docs:
-    if: ${{ github.ref == 'refs/heads/main' }}
+    # if: ${{ github.ref == 'refs/heads/main' }} # temporarily commented out for testing in PR branch
     needs: 
       - build-ngx-charts-on-fhir
       - build-apps


### PR DESCRIPTION
## Overview

- Copy index.html to 404.html so requests will go to Angular router instead of GitHub's 404 page

## How it was tested

- Not tested (cannot publish from PR due to protection rules for github pages environment)

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [ ] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)
