### PR TITLE
RT-683-Rework-summary-card-layout

### DIFF
--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary-card/fhir-chart-summary-card.component.css
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary-card/fhir-chart-summary-card.component.css
@@ -2,13 +2,3 @@
   border-left: 4px solid transparent;
   min-height: 100%;
 }
-.mat-card-subtitle .mat-icon {
-  margin: -8px 0px;
-}
-.mat-card-title {
-  font-size: 20px;
-  max-width: 350px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary-card/fhir-chart-summary-card.component.html
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary-card/fhir-chart-summary-card.component.html
@@ -1,11 +1,6 @@
-<mat-card class="summary-card" [style.background]="getBackgroundStyle()">
-  <mat-card-header>
-    <mat-card-title-group>
-      <mat-card-subtitle *ngIf="subtitle">{{ subtitle }}</mat-card-subtitle>
-      <mat-card-title *ngIf="title" [matTooltip]="title">{{ title }}</mat-card-title>
-    </mat-card-title-group>
-  </mat-card-header>
-  <mat-card-content>
+<div class="card" class="summary-card" [style.background]="getBackgroundStyle()">
+  <div class="card-header"></div>
+  <div class="card-body">
     <ng-content></ng-content>
-  </mat-card-content>
-</mat-card>
+  </div>
+</div>

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary-card/fhir-chart-summary-card.component.html
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary-card/fhir-chart-summary-card.component.html
@@ -1,6 +1,3 @@
-<div class="card" class="summary-card" [style.background]="getBackgroundStyle()">
-  <div class="card-header"></div>
-  <div class="card-body">
+<div class="card summary-card" [style.background]="getBackgroundStyle()">
     <ng-content></ng-content>
-  </div>
 </div>

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart-summary/medication-summary.service.spec.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart-summary/medication-summary.service.spec.ts
@@ -30,7 +30,7 @@ describe('MedicationSummaryService', () => {
       const summaryService = new MedicationSummaryService();
       const authoredOn = new Date('2023-01-01T00:00:00').getTime();
       const layer: DataLayer<'line', MedicationDataPoint[]> = {
-        name: 'Test',
+        name: 'Medications',
         datasets: [
           {
             label: 'one',
@@ -46,7 +46,7 @@ describe('MedicationSummaryService', () => {
       const summary = summaryService.summarize(layer);
       expect(summary).toEqual([
         {
-          name: 'one',
+          'Medications': 'one',
           'Date Written': '1 Jan 2023',
         },
       ]);

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart-summary/medication-summary.service.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart-summary/medication-summary.service.ts
@@ -12,7 +12,7 @@ export class MedicationSummaryService implements SummaryService {
   }
   summarize(layer: DataLayer<TimelineChartType, MedicationDataPoint[]>): Record<string, string>[] {
     return layer.datasets.map((dataset) => ({
-      name: dataset.label ?? '(unknown)',
+      [layer.name]: dataset.label ?? '(unknown)',
       'Date Written': formatDate(Math.max(...dataset.data.map((point) => point.authoredOn))),
     }));
   }

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart-summary/summary.service.spec.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart-summary/summary.service.spec.ts
@@ -1,4 +1,4 @@
-import { DataLayer } from '@elimuinformatics/ngx-charts-on-fhir';
+import { DataLayer } from '../data-layer/data-layer';
 import { StatisticsService } from './statistics.service';
 import { ScatterDataPointSummaryService } from './summary.service';
 
@@ -37,7 +37,7 @@ describe('ScatterDataPointSummaryService', () => {
     it('should include statistics for current and previous timespan', () => {
       const statisticsService = jasmine.createSpyObj<StatisticsService>('StatisticsService', ['getFormattedStatistics']);
       const summaryService = new ScatterDataPointSummaryService(statisticsService);
-      statisticsService.getFormattedStatistics.and.callFake((mockLayer, { min, max }) => ({
+      statisticsService.getFormattedStatistics.and.callFake((layer, { min, max }) => ({
         min: String(min),
         max: String(max),
       }));
@@ -45,13 +45,13 @@ describe('ScatterDataPointSummaryService', () => {
       expect(summary).toEqual([
         {
           [`${mockLayer.name}`]: 'min',
-          [`current ${1}${'days'}`]: '10',
-          [`previous ${1}${'days'}`]: '4',
+          [`current ${1} days`]: '10',
+          [`previous ${1} days`]: '4',
         },
         {
           [`${mockLayer.name}`]: 'max',
-          [`current ${1}${'days'}`]: '15',
-          [`previous ${1}${'days'}`]: '9',
+          [`current ${1} days`]: '15',
+          [`previous ${1} days`]: '9',
         },
       ]);
     });

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart-summary/summary.service.spec.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart-summary/summary.service.spec.ts
@@ -1,6 +1,14 @@
-import { DataLayer } from '../data-layer/data-layer';
+import { DataLayer } from '@elimuinformatics/ngx-charts-on-fhir';
 import { StatisticsService } from './statistics.service';
 import { ScatterDataPointSummaryService } from './summary.service';
+
+const mockLayer: DataLayer = {
+  name: 'Blood pressure',
+  category: ['Vital Signs'],
+  scale: { id: 'Blood pressure (mmHg)' },
+  datasets: [],
+  annotations: [],
+};
 
 describe('ScatterDataPointSummaryService', () => {
   describe('canSummarize', () => {
@@ -29,19 +37,19 @@ describe('ScatterDataPointSummaryService', () => {
     it('should include statistics for current and previous timespan', () => {
       const statisticsService = jasmine.createSpyObj<StatisticsService>('StatisticsService', ['getFormattedStatistics']);
       const summaryService = new ScatterDataPointSummaryService(statisticsService);
-      statisticsService.getFormattedStatistics.and.callFake((layer, { min, max }) => ({
+      statisticsService.getFormattedStatistics.and.callFake((mockLayer, { min, max }) => ({
         min: String(min),
         max: String(max),
       }));
-      const summary = summaryService.summarize({} as DataLayer, { min: 10, max: 15 });
+      const summary = summaryService.summarize(mockLayer, { min: 10, max: 15 });
       expect(summary).toEqual([
         {
-          name: 'min',
+          [`${mockLayer.name}`]: 'min',
           [`current ${1}${'days'}`]: '10',
           [`previous ${1}${'days'}`]: '4',
         },
         {
-          name: 'max',
+          [`${mockLayer.name}`]: 'max',
           [`current ${1}${'days'}`]: '15',
           [`previous ${1}${'days'}`]: '9',
         },

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart-summary/summary.service.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart-summary/summary.service.ts
@@ -21,9 +21,9 @@ export class ScatterDataPointSummaryService implements SummaryService {
   summarize(layer: DataLayer, range: NumberRange): Record<string, string>[] {
     const current = this.stats.getFormattedStatistics(layer, range);
     const prev = this.stats.getFormattedStatistics(layer, previous(range));
-    const days = Math.ceil((range.max - range.min) / MILLISECONDS_PER_DAY)
+    const days = Math.ceil((range.max - range.min) / MILLISECONDS_PER_DAY);
     const summary = Object.keys(current).map((name) => ({
-      name,
+      [layer.name]: name,
       [`current ${days}${'days'}`]: current[name],
       [`previous ${days}${'days'}`]: prev[name],
     }));

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart-summary/summary.service.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart-summary/summary.service.ts
@@ -24,8 +24,8 @@ export class ScatterDataPointSummaryService implements SummaryService {
     const days = Math.ceil((range.max - range.min) / MILLISECONDS_PER_DAY);
     const summary = Object.keys(current).map((name) => ({
       [layer.name]: name,
-      [`current ${days}${'days'}`]: current[name],
-      [`previous ${days}${'days'}`]: prev[name],
+      [`current ${days} days`]: current[name],
+      [`previous ${days} days`]: prev[name],
     }));
     return summary;
   }


### PR DESCRIPTION
## Overview
-Replaced the “name” column heading with the dataset label in the summary card. 
-Remove the mat-card and used a simple card.

## How it was tested
-Tested showcase,cardio-patient, and cardio-health locally.

## Checklist

- [X] The title contains a short meaningful summary
- [X] I have added a link to this PR in the Jira issue
- [X] I have described how this was tested
- [X] I have included screen shots for changes that affect the user interface
- [X] I have updated unit tests
- [X] I have run unit tests locally
- [ ] I have updated documentation (including README)
![cardio-health17](https://user-images.githubusercontent.com/57406228/225916214-1b464db7-6936-40ea-ada8-8382cd701126.png)
ntent.com/57406228/225916081-39ffa151-ca74-4cef-869a
![patient17](https://user-images.githubusercontent.com/57406228/225916234-75702139-da40-4ac1-b946-64a0c48f71cb.png)
-ac3ec8dcd346.png)
![Showcase17](https://user-images.githubusercontent.com/57406228/225916662-204ecdbb-494f-4026-81b1-3b1fbae7dfba.png)

