### PR TITLE
Custom Legend

### DIFF
--- a/projects/cardiovascular-health/src/app/app.component.html
+++ b/projects/cardiovascular-health/src/app/app.component.html
@@ -1,7 +1,7 @@
 <fhir-chart-layout [toolbar]="['loading', 'options']">
   <div class="layout-main">
     <range-selector class="layout-main-range"></range-selector>
-    <fhir-chart class="layout-main-chart" width="100%" height="100%"></fhir-chart>
+    <fhir-chart class="layout-main-chart" width="100%" height="100%" legendPosition="top"></fhir-chart>
     <fhir-chart-summary class="layout-main-summary"></fhir-chart-summary>
   </div>
 </fhir-chart-layout>

--- a/projects/cardiovascular-patient-app/src/app/app.component.html
+++ b/projects/cardiovascular-patient-app/src/app/app.component.html
@@ -17,7 +17,7 @@
   </mat-tab>
   <mat-tab label="See prior BPs">
     <div class="layout-main" id="layout-main">
-      <fhir-chart class="layout-main-chart" width="100%" height="100%" [showLegend]="false" #chart></fhir-chart>
+      <fhir-chart class="layout-main-chart" width="100%" height="100%" legendPosition="none" #chart></fhir-chart>
       <fhir-chart-summary id="summary-card-table"></fhir-chart-summary>
     </div>
   </mat-tab>

--- a/projects/cardiovascular-patient-app/src/app/app.component.html
+++ b/projects/cardiovascular-patient-app/src/app/app.component.html
@@ -1,16 +1,23 @@
 <mat-toolbar>
   <img class="banner-logo" *ngIf="cdsicLogo" src="assets/cdsic-logo-small.png" alt="CDSiC Logo" />
   <span>{{ appTitle }}</span>
+  <span style="flex: auto"></span>
+  <options-menu *ngIf="selectedIndex === 1" [chart]="chart"></options-menu>
 </mat-toolbar>
-<mat-tab-group class="bp-tab-group" mat-stretch-tabs="false" mat-align-tabs="start" [selectedIndex]="selectedIndex"
-  (selectedIndexChange)="selectedIndex = $event">
+<mat-tab-group
+  class="bp-tab-group"
+  mat-stretch-tabs="false"
+  mat-align-tabs="start"
+  [selectedIndex]="selectedIndex"
+  (selectedIndexChange)="selectedIndex = $event"
+>
   <mat-tab label="Report BP">
     <last-report-bp></last-report-bp>
     <report-bp class="report-bp-card" (resourceCreated)="getBpLayerdata()"></report-bp>
   </mat-tab>
   <mat-tab label="See prior BPs">
     <div class="layout-main" id="layout-main">
-      <fhir-chart class="layout-main-chart" width="100%" height="100%"></fhir-chart>
+      <fhir-chart class="layout-main-chart" width="100%" height="100%" [showLegend]="false" #chart></fhir-chart>
       <fhir-chart-summary id="summary-card-table"></fhir-chart-summary>
     </div>
   </mat-tab>

--- a/projects/cardiovascular-patient-app/src/app/app.component.spec.ts
+++ b/projects/cardiovascular-patient-app/src/app/app.component.spec.ts
@@ -4,9 +4,9 @@ import { MatTabGroupHarness } from '@angular/material/tabs/testing';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatTabsModule } from '@angular/material/tabs';
-import { COLOR_PALETTE, DataLayerService } from '@elimuinformatics/ngx-charts-on-fhir';
+import { COLOR_PALETTE, DataLayerService, FhirChartComponent } from '@elimuinformatics/ngx-charts-on-fhir';
 import { EMPTY } from 'rxjs';
-import { Component, EventEmitter, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatCardModule } from '@angular/material/card';
 import { MatToolbarModule } from '@angular/material/toolbar';
@@ -19,17 +19,24 @@ class MockDataLayerService implements DataLayerService {
 }
 
 @Component({ selector: 'fhir-chart' })
-class MockFhirChartComponent { }
+class MockFhirChartComponent {
+  @Input() showLegend?: boolean;
+}
 
 @Component({ selector: 'fhir-chart-summary' })
-class MockFhirChartSummaryComponent { }
+class MockFhirChartSummaryComponent {}
 
 @Component({ selector: 'last-report-bp' })
-class MockLastReportBPComponent { }
+class MockLastReportBPComponent {}
 
 @Component({ selector: 'report-bp' })
 class MockReportBPComponent {
   @Output() resourceCreated = new EventEmitter<number>();
+}
+
+@Component({ selector: 'options-menu' })
+class MockOptionsMenuComponent {
+  @Input() chart?: FhirChartComponent;
 }
 
 describe('AppComponent', () => {
@@ -39,7 +46,14 @@ describe('AppComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [AppComponent, MockFhirChartComponent, MockFhirChartSummaryComponent, MockLastReportBPComponent, MockReportBPComponent],
+      declarations: [
+        AppComponent,
+        MockFhirChartComponent,
+        MockFhirChartSummaryComponent,
+        MockLastReportBPComponent,
+        MockReportBPComponent,
+        MockOptionsMenuComponent,
+      ],
       imports: [NoopAnimationsModule, MatTabsModule, MatCardModule, MatToolbarModule],
       providers: [
         { provide: DataLayerService, useClass: MockDataLayerService, multi: true },
@@ -60,6 +74,4 @@ describe('AppComponent', () => {
     reportBPComponent.componentInstance.resourceCreated.next(1);
     expect(await tabHarness[1].isSelected()).toBe(true);
   });
-  
 });
-

--- a/projects/cardiovascular-patient-app/src/app/app.component.spec.ts
+++ b/projects/cardiovascular-patient-app/src/app/app.component.spec.ts
@@ -4,7 +4,7 @@ import { MatTabGroupHarness } from '@angular/material/tabs/testing';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatTabsModule } from '@angular/material/tabs';
-import { COLOR_PALETTE, DataLayerService, FhirChartComponent } from '@elimuinformatics/ngx-charts-on-fhir';
+import { COLOR_PALETTE, DataLayerService, FhirChartComponent, LegendPosition } from '@elimuinformatics/ngx-charts-on-fhir';
 import { EMPTY } from 'rxjs';
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -20,7 +20,7 @@ class MockDataLayerService implements DataLayerService {
 
 @Component({ selector: 'fhir-chart' })
 class MockFhirChartComponent {
-  @Input() showLegend?: boolean;
+  @Input() legendPosition?: LegendPosition;
 }
 
 @Component({ selector: 'fhir-chart-summary' })

--- a/projects/cardiovascular-patient-app/src/app/app.module.ts
+++ b/projects/cardiovascular-patient-app/src/app/app.module.ts
@@ -12,17 +12,12 @@ import { MatButtonModule } from '@angular/material/button';
 import paletteProvider from './providers/palette-provider';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTabsModule } from '@angular/material/tabs';
-import {
-  FhirChartModule,
-  COLOR_PALETTE,
-  DataLayerBrowserModule,
-  FhirChartSummaryModule,
-  FhirDataService,
-} from '@elimuinformatics/ngx-charts-on-fhir';
+import { FhirChartModule, COLOR_PALETTE, DataLayerBrowserModule, FhirChartSummaryModule, FhirDataService } from '@elimuinformatics/ngx-charts-on-fhir';
 import { environment } from '../environments/environment';
 import { summaryProviders } from './providers/summary-providers';
 import { ReportBPModule } from './report-bp/report-bp.module';
 import { LastReportBPModule } from './last-report-bp/last-report-bp.module';
+import { OptionsMenuModule } from './options-menu/options-menu.module';
 
 function initializeFhirClientFactory(service: FhirDataService): () => Promise<void> {
   return () => service.initialize(environment.clientState);
@@ -43,7 +38,8 @@ function initializeFhirClientFactory(service: FhirDataService): () => Promise<vo
     MatToolbarModule,
     MatTabsModule,
     ReportBPModule,
-    LastReportBPModule
+    LastReportBPModule,
+    OptionsMenuModule,
   ],
   providers: [
     { provide: APP_INITIALIZER, useFactory: initializeFhirClientFactory, deps: [FhirDataService], multi: true },

--- a/projects/cardiovascular-patient-app/src/app/options-menu/options-menu.component.html
+++ b/projects/cardiovascular-patient-app/src/app/options-menu/options-menu.component.html
@@ -1,0 +1,8 @@
+<button mat-icon-button aria-label="Options" [matMenuTriggerFor]="optionsMenu">
+  <mat-icon>more_vert</mat-icon>
+</button>
+<mat-menu #optionsMenu="matMenu">
+  <div mat-menu-item>
+    <mat-slide-toggle (change)="chart?.toggleLegend($event.checked)" [checked]="chart?.showLegend">Legend</mat-slide-toggle>
+  </div>
+</mat-menu>

--- a/projects/cardiovascular-patient-app/src/app/options-menu/options-menu.component.html
+++ b/projects/cardiovascular-patient-app/src/app/options-menu/options-menu.component.html
@@ -3,6 +3,6 @@
 </button>
 <mat-menu #optionsMenu="matMenu">
   <div mat-menu-item>
-    <mat-slide-toggle (change)="chart?.toggleLegend($event.checked)" [checked]="chart?.showLegend">Legend</mat-slide-toggle>
+    <mat-slide-toggle (change)="toggleLegend($event.checked)" [checked]="chart?.legendPosition !== 'none'">Legend</mat-slide-toggle>
   </div>
 </mat-menu>

--- a/projects/cardiovascular-patient-app/src/app/options-menu/options-menu.component.spec.ts
+++ b/projects/cardiovascular-patient-app/src/app/options-menu/options-menu.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { OptionsMenuComponent } from './options-menu.component';
+import { OptionsMenuModule } from './options-menu.module';
 
 describe('OptionsMenuComponent', () => {
   let component: OptionsMenuComponent;
@@ -8,7 +8,7 @@ describe('OptionsMenuComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [OptionsMenuComponent],
+      imports: [OptionsMenuModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(OptionsMenuComponent);

--- a/projects/cardiovascular-patient-app/src/app/options-menu/options-menu.component.spec.ts
+++ b/projects/cardiovascular-patient-app/src/app/options-menu/options-menu.component.spec.ts
@@ -1,22 +1,52 @@
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { OptionsMenuComponent } from './options-menu.component';
 import { OptionsMenuModule } from './options-menu.module';
+import { MatMenuHarness } from '@angular/material/menu/testing';
+import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('OptionsMenuComponent', () => {
   let component: OptionsMenuComponent;
   let fixture: ComponentFixture<OptionsMenuComponent>;
+  let loader: HarnessLoader;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [OptionsMenuModule],
+      imports: [OptionsMenuModule, NoopAnimationsModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(OptionsMenuComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should enable the legend when checked', async () => {
+    component.chart = { legendPosition: 'none' } as any;
+    const menu = await loader.getHarness(MatMenuHarness)
+    await menu.open();
+    const childLoader = await menu.getChildLoader('*');
+    const legendToggle = await childLoader.getHarness(MatSlideToggleHarness);
+    expect(await legendToggle.isChecked()).toBe(false);
+    await legendToggle.check();
+    expect(component.chart?.legendPosition).toBe('float');
+  });
+
+  it('should disable the legend when unchecked', async () => {
+    component.chart = { legendPosition: 'float' } as any;
+    const menu = await loader.getHarness(MatMenuHarness);
+    await menu.open();
+    const childLoader = await menu.getChildLoader('*');
+    const legendToggle = await childLoader.getHarness(MatSlideToggleHarness);
+    expect(await legendToggle.isChecked()).toBe(true);
+    await legendToggle.uncheck();
+    expect(component.chart?.legendPosition).toBe('none');
+  });
+
 });

--- a/projects/cardiovascular-patient-app/src/app/options-menu/options-menu.component.spec.ts
+++ b/projects/cardiovascular-patient-app/src/app/options-menu/options-menu.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { OptionsMenuComponent } from './options-menu.component';
+
+describe('OptionsMenuComponent', () => {
+  let component: OptionsMenuComponent;
+  let fixture: ComponentFixture<OptionsMenuComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [OptionsMenuComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(OptionsMenuComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/cardiovascular-patient-app/src/app/options-menu/options-menu.component.ts
+++ b/projects/cardiovascular-patient-app/src/app/options-menu/options-menu.component.ts
@@ -7,4 +7,9 @@ import { FhirChartComponent } from '@elimuinformatics/ngx-charts-on-fhir';
 })
 export class OptionsMenuComponent {
   @Input() chart?: FhirChartComponent;
+  toggleLegend(value: boolean) {
+    if (this.chart) {
+      this.chart.legendPosition = value ? 'float' : 'none';
+    }
+  }
 }

--- a/projects/cardiovascular-patient-app/src/app/options-menu/options-menu.component.ts
+++ b/projects/cardiovascular-patient-app/src/app/options-menu/options-menu.component.ts
@@ -1,0 +1,10 @@
+import { Component, Input } from '@angular/core';
+import { FhirChartComponent } from '@elimuinformatics/ngx-charts-on-fhir';
+
+@Component({
+  selector: 'options-menu',
+  templateUrl: './options-menu.component.html',
+})
+export class OptionsMenuComponent {
+  @Input() chart?: FhirChartComponent;
+}

--- a/projects/cardiovascular-patient-app/src/app/options-menu/options-menu.module.ts
+++ b/projects/cardiovascular-patient-app/src/app/options-menu/options-menu.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { OptionsMenuComponent } from './options-menu.component';
+import { MatIconModule } from '@angular/material/icon';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatButtonModule } from '@angular/material/button';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+@NgModule({
+  declarations: [OptionsMenuComponent],
+  imports: [CommonModule, MatButtonModule, MatIconModule, MatMenuModule, MatDividerModule, MatSlideToggleModule],
+  exports: [OptionsMenuComponent],
+})
+export class OptionsMenuModule {}

--- a/projects/cardiovascular-patient-app/src/app/options-menu/options-menu.module.ts
+++ b/projects/cardiovascular-patient-app/src/app/options-menu/options-menu.module.ts
@@ -3,12 +3,11 @@ import { CommonModule } from '@angular/common';
 import { OptionsMenuComponent } from './options-menu.component';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
-import { MatDividerModule } from '@angular/material/divider';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 @NgModule({
   declarations: [OptionsMenuComponent],
-  imports: [CommonModule, MatButtonModule, MatIconModule, MatMenuModule, MatDividerModule, MatSlideToggleModule],
+  imports: [CommonModule, MatButtonModule, MatIconModule, MatMenuModule, MatSlideToggleModule],
   exports: [OptionsMenuComponent],
 })
 export class OptionsMenuModule {}

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart-legend/fhir-chart-legend.component.css
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart-legend/fhir-chart-legend.component.css
@@ -1,3 +1,8 @@
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0px 8px;
+}
 .legend-item {
   display: flex;
   align-items: center;

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart-legend/fhir-chart-legend.component.css
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart-legend/fhir-chart-legend.component.css
@@ -1,0 +1,11 @@
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 2px;
+}
+.legend-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart-legend/fhir-chart-legend.component.html
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart-legend/fhir-chart-legend.component.html
@@ -1,0 +1,18 @@
+<div class="legend">
+  <ng-container *ngFor="let layer of layerManager.enabledLayers$ | async">
+    <ng-container *ngFor="let dataset of layer.datasets">
+      <div class="legend-item" *ngIf="!dataset.hidden">
+        <div class="legend-icon" [ngSwitch]="dataset.pointStyle" [style.color]="colorService.getColor(dataset)">
+          <mat-icon *ngSwitchCase="'circle'">circle</mat-icon>
+          <mat-icon *ngSwitchCase="'rect'">square</mat-icon>
+          <mat-icon *ngSwitchCase="'rectRot'" style="rotate: 45deg; scale: 0.8">square</mat-icon>
+          <mat-icon *ngSwitchCase="'triangle'" svgIcon="triangle"></mat-icon>
+          <mat-icon *ngSwitchDefault>square</mat-icon>
+        </div>
+        <div>
+          {{ dataset.label }}
+        </div>
+      </div>
+    </ng-container>
+  </ng-container>
+</div>

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart-legend/fhir-chart-legend.component.spec.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart-legend/fhir-chart-legend.component.spec.ts
@@ -1,0 +1,27 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { COLOR_PALETTE } from '../data-layer/data-layer-color.service';
+import { DataLayerManagerService } from '../data-layer/data-layer-manager.service';
+import { FhirChartLegendComponent } from './fhir-chart-legend.component';
+import { FhirChartLegendModule } from './fhir-chart-legend.module';
+
+const mockLayerManager = {}
+
+describe('FhirChartLegendComponent', () => {
+  let component: FhirChartLegendComponent;
+  let fixture: ComponentFixture<FhirChartLegendComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FhirChartLegendModule],
+      providers: [{ provide: DataLayerManagerService, useValue: mockLayerManager }, { provide: COLOR_PALETTE, useValue: []}]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FhirChartLegendComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart-legend/fhir-chart-legend.component.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart-legend/fhir-chart-legend.component.ts
@@ -1,0 +1,23 @@
+import { Component } from '@angular/core';
+import { MatIconRegistry } from '@angular/material/icon';
+import { DomSanitizer } from '@angular/platform-browser';
+import { DataLayerColorService } from '../data-layer/data-layer-color.service';
+import { DataLayerManagerService } from '../data-layer/data-layer-manager.service';
+
+const SVG_TRIANGLE = '<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24"><path d="M2 20 12.05 4 22 20Z"/></svg>';
+
+@Component({
+  selector: 'fhir-chart-legend',
+  templateUrl: './fhir-chart-legend.component.html',
+  styleUrls: ['./fhir-chart-legend.component.css'],
+})
+export class FhirChartLegendComponent {
+  constructor(
+    public layerManager: DataLayerManagerService,
+    public colorService: DataLayerColorService,
+    iconRegistry: MatIconRegistry,
+    sanitizer: DomSanitizer
+  ) {
+    iconRegistry.addSvgIconLiteral('triangle', sanitizer.bypassSecurityTrustHtml(SVG_TRIANGLE));
+  }
+}

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart-legend/fhir-chart-legend.module.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart-legend/fhir-chart-legend.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FhirChartLegendComponent } from './fhir-chart-legend.component';
+import { MatIconModule } from '@angular/material/icon';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { MatButtonModule } from '@angular/material/button';
+
+@NgModule({
+  declarations: [FhirChartLegendComponent],
+  imports: [CommonModule, MatIconModule, MatButtonModule, OverlayModule],
+  exports: [FhirChartLegendComponent],
+})
+export class FhirChartLegendModule {}

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.css
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.css
@@ -18,3 +18,12 @@
   justify-content: center;
   align-items: center;
 }
+
+.legend {
+  position: absolute;
+  top: 0;
+  left: 60px;
+  background-color: rgba(255, 255, 255, 0.8);
+  border-radius: 8px;
+  padding: 4px;
+}

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.css
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.css
@@ -1,4 +1,9 @@
+.legend-container {
+  display: grid;
+  grid-template-rows: max-content auto max-content;
+}
 .chart-container {
+  grid-row: 2;
   position: relative;
 }
 
@@ -19,7 +24,7 @@
   align-items: center;
 }
 
-.legend {
+.legend-float {
   position: absolute;
   top: 0;
   left: 60px;

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.html
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.html
@@ -1,25 +1,32 @@
-<div class="chart-container" [style.width]="width" [style.height]="height">
-  <div class="chart-container-resize-fix">
-    <canvas
-      *ngIf="datasets && datasets.length > 0; else empty"
-      width="100%"
-      baseChart
-      id="baseChart"
-      [type]="type ?? defaultType"
-      [datasets]="datasets"
-      [options]="options ?? defaultOptions"
-    ></canvas>
-    <ng-template #empty>
-      <div class="empty-message">
-        <div class="empty-message-content">
-          <ng-container *ngIf="layerManager.loading$ | async; else doneLoading">
-            <div>Loading data...</div>
-            <mat-progress-bar mode="indeterminate"></mat-progress-bar>
-          </ng-container>
-          <ng-template #doneLoading>No data layers are selected</ng-template>
+<div class="legend-container" [style.width]="width" [style.height]="height">
+  <fhir-chart-legend
+    class="legend-top"
+    *ngIf="legendPosition === 'top' || legendPosition === 'bottom'"
+    [style.gridRow]="gridRow[legendPosition]"
+  ></fhir-chart-legend>
+  <div class="chart-container">
+    <div class="chart-container-resize-fix">
+      <canvas
+        *ngIf="datasets && datasets.length > 0; else empty"
+        width="100%"
+        baseChart
+        id="baseChart"
+        [type]="type ?? defaultType"
+        [datasets]="datasets"
+        [options]="options ?? defaultOptions"
+      ></canvas>
+      <ng-template #empty>
+        <div class="empty-message">
+          <div class="empty-message-content">
+            <ng-container *ngIf="layerManager.loading$ | async; else doneLoading">
+              <div>Loading data...</div>
+              <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+            </ng-container>
+            <ng-template #doneLoading>No data layers are selected</ng-template>
+          </div>
         </div>
-      </div>
-    </ng-template>
-    <fhir-chart-legend class="legend mat-elevation-z2" [hidden]="!showLegend" cdkDrag cdkDragBoundary=".chart-container"></fhir-chart-legend>
+      </ng-template>
+      <fhir-chart-legend *ngIf="legendPosition == 'float'" class="legend-float mat-elevation-z2" cdkDrag cdkDragBoundary=".chart-container"></fhir-chart-legend>
+    </div>
   </div>
 </div>

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.html
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.html
@@ -20,5 +20,6 @@
         </div>
       </div>
     </ng-template>
+    <fhir-chart-legend class="legend mat-elevation-z2" [hidden]="!showLegend" cdkDrag cdkDragBoundary=".chart-container"></fhir-chart-legend>
   </div>
 </div>

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.ts
@@ -10,6 +10,8 @@ import { FhirChartConfigurationService } from './fhir-chart-configuration.servic
 import { MedicationScale } from './medication-scale';
 import { scaleStackDividerPlugin } from './scale-stack-divider-plugin';
 
+export type LegendPosition = 'none' | 'float' | 'top' | 'bottom';
+
 /**
  * See `*Chart` for example usage.
  */
@@ -31,9 +33,10 @@ export class FhirChartComponent implements OnInit {
   @Input() width: string = '600px';
   @Input() height: string = '300px';
 
-  @Input() showLegend = true;
-  
-  constructor(private configService: FhirChartConfigurationService, public layerManager: DataLayerManagerService) { }
+  @Input() legendPosition: LegendPosition = 'float';
+  readonly gridRow = { top: 1, bottom: 3 } as const;
+
+  constructor(private configService: FhirChartConfigurationService, public layerManager: DataLayerManagerService) {}
 
   ngOnInit(): void {
     Chart.register(annotationPlugin, zoomPlugin, scaleStackDividerPlugin);
@@ -83,9 +86,4 @@ export class FhirChartComponent implements OnInit {
   ngAfterViewChecked() {
     this.configService.chart = Chart.getChart('baseChart');
   }
-
-  toggleLegend(value?: boolean) {
-    this.showLegend = value ?? !this.showLegend;
-  }
-
 }

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Input, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { Chart, ChartConfiguration } from 'chart.js';
 import 'chartjs-adapter-date-fns';
 import annotationPlugin from 'chartjs-plugin-annotation';
@@ -31,11 +31,9 @@ export class FhirChartComponent implements OnInit {
   @Input() width: string = '600px';
   @Input() height: string = '300px';
 
-  // @ViewChild(FhirChartLegendToggleComponent) legendToggle?: FhirChartLegendToggleComponent;
-
   @Input() showLegend = true;
   
-  constructor(private configService: FhirChartConfigurationService, public layerManager: DataLayerManagerService, private elementRef: ElementRef) { }
+  constructor(private configService: FhirChartConfigurationService, public layerManager: DataLayerManagerService) { }
 
   ngOnInit(): void {
     Chart.register(annotationPlugin, zoomPlugin, scaleStackDividerPlugin);

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, ElementRef, Input, OnInit } from '@angular/core';
 import { Chart, ChartConfiguration } from 'chart.js';
 import 'chartjs-adapter-date-fns';
 import annotationPlugin from 'chartjs-plugin-annotation';
@@ -31,7 +31,11 @@ export class FhirChartComponent implements OnInit {
   @Input() width: string = '600px';
   @Input() height: string = '300px';
 
-  constructor(private configService: FhirChartConfigurationService, public layerManager: DataLayerManagerService) {}
+  // @ViewChild(FhirChartLegendToggleComponent) legendToggle?: FhirChartLegendToggleComponent;
+
+  @Input() showLegend = true;
+  
+  constructor(private configService: FhirChartConfigurationService, public layerManager: DataLayerManagerService, private elementRef: ElementRef) {}
 
   ngOnInit(): void {
     Chart.register(annotationPlugin, zoomPlugin, scaleStackDividerPlugin);
@@ -69,6 +73,9 @@ export class FhirChartComponent implements OnInit {
       },
     };
 
+    // we use a custom legend component instead
+    Chart.defaults.plugins.legend.display = false;
+
     this.configService.chartConfig$.subscribe((config) => {
       this.datasets = config.data.datasets;
       this.options = config.options;
@@ -77,5 +84,9 @@ export class FhirChartComponent implements OnInit {
 
   ngAfterViewChecked() {
     this.configService.chart = Chart.getChart('baseChart');
+  }
+
+  toggleLegend(value?: boolean) {
+    this.showLegend = value ?? !this.showLegend;
   }
 }

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.module.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.module.ts
@@ -3,10 +3,11 @@ import { FhirChartComponent } from './fhir-chart.component';
 import { NgChartsModule } from 'ng2-charts';
 import { CommonModule } from '@angular/common';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
-
+import { FhirChartLegendModule } from '../fhir-chart-legend/fhir-chart-legend.module';
+import { DragDropModule } from '@angular/cdk/drag-drop';
 @NgModule({
   declarations: [FhirChartComponent],
-  imports: [CommonModule, NgChartsModule, MatProgressBarModule],
+  imports: [CommonModule, NgChartsModule, MatProgressBarModule, FhirChartLegendModule, DragDropModule],
   exports: [FhirChartComponent],
 })
 export class FhirChartModule {}

--- a/projects/showcase/src/app/app.component.html
+++ b/projects/showcase/src/app/app.component.html
@@ -1,7 +1,7 @@
 <fhir-chart-layout [toolbar]="toolbar" [active]="active">
   <div class="layout-main">
     <range-selector class="layout-main-range"></range-selector>
-    <fhir-chart class="layout-main-chart" width="100%" height="100%"></fhir-chart>
+    <fhir-chart class="layout-main-chart" width="100%" height="100%" legendPosition="top"></fhir-chart>
     <fhir-chart-summary class="layout-main-summary"></fhir-chart-summary>
   </div>
 </fhir-chart-layout>


### PR DESCRIPTION
## Overview

ngx-charts-on-fhir:
- Replaces the chart.js legend with a custom legend component
- Legend component can be placed at the top, bottom, or floating (`legendPosition` input on fhir-chart component)
- Floating legend can be moved around by dragging it
- Legend shows the correct colors and symbols for symbols that can be set via dataset-options component
- If an app programmatically assigns an unsupported symbol, it will show up as a square in the legend

cardiovascular-patient-app:
- Legend is hidden by default
- Added a menu to the toolbar for toggling the legend

showcase & cardiovascular-health:
- Legend is displayed at the top of the chart

## How it was tested

- Ran showcase, cardio, and patient apps
- Tested all different screen sizes to make sure legend displays correctly

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [x] I have included screen shots for changes that affect the user interface
- [x] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
