### PR TITLE
RT-688_Unit_test_error:Can't bind to hideRemoveLayerButton

### DIFF
--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart-layout/fhir-chart-layout.component.spec.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart-layout/fhir-chart-layout.component.spec.ts
@@ -15,7 +15,9 @@ class MockDataLayerToolbarComponent {
 class MockDataLayerBrowserComponent {}
 
 @Component({ selector: 'data-layer-list', template: '' })
-class MockDataLayerListComponent {}
+class MockDataLayerListComponent {
+  @Input() hideRemoveLayerButton?: boolean = false;
+}
 
 describe('FhirChartLayoutComponent', () => {
   let component: FhirChartLayoutComponent;

--- a/projects/ngx-charts-on-fhir/src/test.ts
+++ b/projects/ngx-charts-on-fhir/src/test.ts
@@ -6,4 +6,8 @@ import { getTestBed } from '@angular/core/testing';
 import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
 
 // First, initialize the Angular testing environment.
-getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(),
+    {
+        errorOnUnknownElements: true,
+        errorOnUnknownProperties: true
+    });


### PR DESCRIPTION
## Overview
configured the Angular TestBed to fail the spec if there are any unknown elements/properties.
Add MockDataLayerListComponent for use hideRemoveLayerButton in fhir-chart-layout.component.spec file

## How it was tested
Tested using run test cases locally for all charts-on-fhir apps and charts-on-fhir library.

## Checklist

- [ ] The title contains a short meaningful summary
- [ ] I have added a link to this PR in the Jira issue
- [ ] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)
