### PR TITLE
RT-689-fail-specs-with-no-expectations:Jasmine should fail specs with no expectations

### DIFF
--- a/karma.base.conf.js
+++ b/karma.base.conf.js
@@ -17,6 +17,7 @@ module.exports = (config, project) => ({
       // the possible options are listed at https://jasmine.github.io/api/edge/Configuration.html
       // for example, you can disable the random execution with `random: false`
       // or set a specific seed with `seed: 4321`
+      failSpecWithNoExpectations: true
     },
     clearContext: false, // leave Jasmine Spec Runner output visible in browser
   },


### PR DESCRIPTION
## Overview
Set `failSpecWithNoExpectations` true in karma.base.conf file.
![image](https://user-images.githubusercontent.com/117890382/226863114-e7a9a502-f7b4-4240-9d7c-e39e7ab49f4c.png)

![image](https://user-images.githubusercontent.com/117890382/226863347-39755865-7324-49fe-b9cc-264566c3d69a.png)

## How it was tested
Tested using run test cases without except() for all charts-on-fhir apps.


## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [x] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
