### PR TITLE
Fix error: Cannot read properties of undefined

### DIFF
--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.spec.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.spec.ts
@@ -348,12 +348,14 @@ describe('FhirChartConfigurationService', () => {
       expect(configService.isAutoZoom).toBe(false);
     });
 
-    it('should set initial zoom if called before chart is initialized', () => {
+    it('should set initial zoom if called before chart is initialized', waitForAsync(() => {
       configService.zoom({ min: 1, max: 2 });
-      configService.chart = jasmine.createSpyObj<Chart>('Chart', ['zoomScale']);
-      expect(configService.isAutoZoom).toBe(false);
-      expect(configService.chart?.zoomScale).toHaveBeenCalledWith('timeline', { min: 1, max: 2 }, 'zoom');
-    });
+      configService.chartConfig$.subscribe((config) => {
+        expect(configService.isAutoZoom).toBe(false);
+        expect(config.options?.scales?.['timeline']?.min).toBe(1);
+        expect(config.options?.scales?.['timeline']?.max).toBe(2);
+      });
+    }));
 
   });
 

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.ts
@@ -55,14 +55,6 @@ export class FhirChartConfigurationService {
   set chart(value: Chart | undefined) {
     if (this._chart !== value) {
       this._chart = value;
-      if (this.chart && this.isZoomRangeLocked && this.timeline.min != null && this.timeline.max != null) {
-        // set initial zoom range if zoom() was called before the chart was initialized
-        const range = {
-          min: Number(this.timeline.min),
-          max: Number(this.timeline.max),
-        };
-        this.chart.zoomScale('timeline', range, 'zoom');
-      }
     }
   }
 


### PR DESCRIPTION
## Overview

- The call to `zoomScale()` in chart setter was unnecessary. Setting the scale min/max is sufficient to set the initial zoom range. The chart will automatically zoom to those bounds on the first update.

## How it was tested

- Ran patient app with Logica Open environment patient id: 31059
- Reloaded the page multiple times, switched to chart tab before/during/after loading data and checked initial zoom range.

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [x] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
