### PR TITLE
RT-691-Legend-sort-order

### DIFF
--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart-legend/fhir-chart-legend.component.html
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart-legend/fhir-chart-legend.component.html
@@ -1,6 +1,6 @@
 <div class="legend">
   <ng-container *ngFor="let layer of layerManager.enabledLayers$ | async">
-    <ng-container *ngFor="let dataset of layer.datasets">
+    <ng-container *ngFor="let dataset of layer.datasets|sortBy:'desc':'label'">
       <div class="legend-item" *ngIf="!dataset.hidden">
         <div class="legend-icon" [ngSwitch]="dataset.pointStyle" [style.color]="colorService.getColor(dataset)">
           <mat-icon *ngSwitchCase="'circle'">circle</mat-icon>

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart-legend/fhir-chart-legend.module.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart-legend/fhir-chart-legend.module.ts
@@ -4,9 +4,10 @@ import { FhirChartLegendComponent } from './fhir-chart-legend.component';
 import { MatIconModule } from '@angular/material/icon';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { MatButtonModule } from '@angular/material/button';
+import { SortByPipe } from './sort-by.pipe';
 
 @NgModule({
-  declarations: [FhirChartLegendComponent],
+  declarations: [FhirChartLegendComponent,SortByPipe],
   imports: [CommonModule, MatIconModule, MatButtonModule, OverlayModule],
   exports: [FhirChartLegendComponent],
 })

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart-legend/sort-by.pipe.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart-legend/sort-by.pipe.ts
@@ -1,0 +1,16 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { orderBy, sortBy } from 'lodash';
+
+@Pipe({ name: 'sortBy' })
+export class SortByPipe implements PipeTransform {
+
+    transform(value: any[], order: any = '', column: string = ''): any[] {
+        if (!value || order === '' || !order) { return value; } // no array
+        if (!column || column === '') {
+            if (order === 'asc') { return value.sort() }
+            else { return value.sort().reverse(); }
+        } // sort 1d array
+        if (value.length <= 1) { return value; } // array with only one item
+        return orderBy(value, [column], [order]);
+    }
+}


### PR DESCRIPTION
## Overview
Added a custom pipe to sort the Blood Pressure legend in the order displayed in the chart.
Create a sort-by.pipe.ts file for writing logic for the custom pipe.
![image](https://user-images.githubusercontent.com/117890382/227188377-afda438f-1e9e-4cf7-85cf-48066cc02f49.png)
![image](https://user-images.githubusercontent.com/117890382/227188703-e1b2ea77-635a-4d89-865f-1bf6f9994932.png)

## How it was tested
Tested Using run all charts-on-fhir apps locally.


## Checklist

- [ ] The title contains a short meaningful summary
- [ ] I have added a link to this PR in the Jira issue
- [ ] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)
