### PR TITLE
Month subtraction bug

### DIFF
--- a/projects/ngx-charts-on-fhir/src/lib/range-selector/range-selector.component.spec.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/range-selector/range-selector.component.spec.ts
@@ -14,8 +14,8 @@ import { MatNativeDateModule } from '@angular/material/core';
 import { FormsModule } from '@angular/forms';
 import { FhirChartConfigurationService } from '../fhir-chart/fhir-chart-configuration.service';
 
-const max = 1650906227000; // Apr 25, 2022
-const min = 1578330227000; // Jan 6, 2020
+const max = new Date('2022-03-30T00:00').getTime();
+const min = new Date('2022-01-06T00:00').getTime();
 
 class MockConfigService {
   timelineRange$ = of({ min, max });
@@ -23,7 +23,7 @@ class MockConfigService {
   resetZoom = jasmine.createSpy('resetZoom');
 }
 
-describe('RangeSelectorComponent', () => {
+fdescribe('RangeSelectorComponent', () => {
   let component: RangeSelectorComponent;
   let fixture: ComponentFixture<RangeSelectorComponent>;
   let element: DebugElement;
@@ -52,39 +52,35 @@ describe('RangeSelectorComponent', () => {
 
   it('should display the range selector', () => {
     fixture.detectChanges();
-    const rangeSelector = element.query(By.css(".range-selector"));
+    const rangeSelector = element.query(By.css('.range-selector'));
     expect(rangeSelector).toBeTruthy();
   });
 
   it('should calculate proper 1 month ago date from max layer date', async () => {
     let ButtonInputGroup = await loader.getHarness(MatButtonToggleHarness.with({ selector: "[id='1 mo']" }));
     await ButtonInputGroup.check();
-    const expectedMinDate = new Date(max);
-    expectedMinDate.setMonth(new Date(max).getMonth() - 1);
+    const expectedMinDate = new Date('2022-02-28T00:00');
     expect(component.minDate).toEqual(expectedMinDate);
   });
 
   it('should calculate proper 3 month ago date from max layer date', async () => {
     let ButtonInput = await loader.getHarness(MatButtonToggleHarness.with({ selector: "[id='3 mo']" }));
     await ButtonInput.check();
-    const expectedMinDate = new Date(max);
-    expectedMinDate.setMonth(new Date(max).getMonth() - 3);
+    const expectedMinDate = new Date('2021-12-30T00:00');
     expect(component.minDate).toEqual(expectedMinDate);
   });
 
   it('should calculate proper 6 month ago date from max layer date', async () => {
     let ButtonInput = await loader.getHarness(MatButtonToggleHarness.with({ selector: "[id='6 mo']" }));
     await ButtonInput.check();
-    const expectedMinDate = new Date(max);
-    expectedMinDate.setMonth(new Date(max).getMonth() - 6);
+    const expectedMinDate = new Date('2021-09-30T00:00');
     expect(component.minDate).toEqual(expectedMinDate);
   });
 
   it('should calculate proper 12 month ago date from max layer date', async () => {
     let ButtonInput = await loader.getHarness(MatButtonToggleHarness.with({ selector: "[id='1 y']" }));
     await ButtonInput.check();
-    const expectedMinDate = new Date(max);
-    expectedMinDate.setMonth(new Date(max).getMonth() - 12);
+    const expectedMinDate = new Date('2021-03-30T00:00');
     expect(component.minDate).toEqual(expectedMinDate);
   });
 
@@ -109,17 +105,15 @@ describe('RangeSelectorComponent', () => {
   });
 
   it('should check month difference between two dates', async () => {
-    const componentMaxdate = new Date();
-    const componentMindate = new Date();
-    const monthCount = 1;
-    componentMindate.setMonth(componentMindate.getMonth() - monthCount);
+    const componentMaxdate = new Date('2022-01-01T00:00');
+    const componentMindate = new Date('2021-12-31T23:59');
     const months = component.calculateMonthDiff(componentMindate, componentMaxdate);
-    expect(months).toEqual(monthCount);
+    expect(months).toEqual(1);
   });
 
   it('should subscribe timelineRange when the component initializes and set minDate and maxDate', async () => {
     expect(component.minDate).toEqual(new Date(min));
     expect(component.maxDate).toEqual(new Date(max));
-    expect(component.selectedButton).toEqual(27);
+    expect(component.selectedButton).toEqual(2);
   });
 });

--- a/projects/ngx-charts-on-fhir/src/lib/range-selector/range-selector.component.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/range-selector/range-selector.component.ts
@@ -36,8 +36,7 @@ export class RangeSelectorComponent {
 
   updateRangeSelector(monthCount: number) {
     if (this.maxDate && monthCount) {
-      this.minDate = new Date(this.maxDate);
-      this.minDate.setMonth(new Date(this.maxDate).getMonth() - monthCount);
+      this.minDate = subtractMonths(this.maxDate, monthCount);
       this.configService.zoom({
         min: this.minDate.getTime(),
         max: this.maxDate.getTime(),
@@ -73,4 +72,16 @@ export class RangeSelectorComponent {
     }
     return 0;
   }
+}
+
+function subtractMonths(oldDate: Date, months: number): Date {
+  const newDate = new Date(oldDate);
+  newDate.setMonth(oldDate.getMonth() - months);
+  // If day-of-the-month (getDate) has changed, it's because the day did not exist 
+  // in the new month (e.g.Feb 30) so setMonth rolled over into the next month.
+  // We can fix this by setting day-of-month to 0, so it rolls back to last day of previous month.
+  if (newDate.getDate() < oldDate.getDate()) {
+    newDate.setDate(0);
+  }
+  return newDate;
 }


### PR DESCRIPTION
## Overview

- Fixed range-selector month subtraction bug for months with fewer days.
- Improved range-selector unit tests

## How it was tested

- Ran unit tests
- Ran showcase app and clicked on all the month buttons to make sure it zooms to correct range.

## Checklist

- [x] The title contains a short meaningful summary
- [ ] I have added a link to this PR in the Jira issue
- [ ] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)
