### PR TITLE
RT-707-reference-range-tooltip-home-measurements

### DIFF
--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart-summary/home-measurement-summary.service.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart-summary/home-measurement-summary.service.ts
@@ -11,7 +11,7 @@ export const HOME_DATASET_LABEL_SUFFIX = ' (Home)';
   providedIn: 'root',
 })
 export class HomeMeasurementSummaryService implements SummaryService {
-  constructor(private baseSummaryService: ScatterDataPointSummaryService) {}
+  constructor(private baseSummaryService: ScatterDataPointSummaryService) { }
 
   canSummarize(layer: DataLayer): boolean {
     return this.baseSummaryService.canSummarize(layer) && layer.datasets.some((dataset) => dataset.label?.endsWith(HOME_DATASET_LABEL_SUFFIX));
@@ -24,7 +24,7 @@ export class HomeMeasurementSummaryService implements SummaryService {
   }
 }
 
-function getOriginalLabel(dataset: Dataset): string | undefined {
+export function getOriginalLabel(dataset: Dataset): string | undefined {
   if (dataset.label && dataset.label.endsWith(HOME_DATASET_LABEL_SUFFIX)) {
     return dataset.label.substring(0, dataset.label.length - HOME_DATASET_LABEL_SUFFIX.length);
   }

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart-summary/statistics.service.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart-summary/statistics.service.ts
@@ -183,9 +183,10 @@ function getDay(point: ScatterDataPoint): string {
 
 /** Factory for generating functions that check if any given annotation is a reference range for the bound dataset */
 function isReferenceRangeFor(dataset: Dataset) {
+  const datasetLabel = dataset.label?.includes('(Home)') ? dataset.label.split('(Home)')[0].trim() : dataset.label;
   return function isReferenceRange(annotation: DeepPartial<AnnotationOptions>): annotation is ReferenceRange {
     return (
-      (annotation as BoxAnnotationOptions)?.label?.content === `${dataset.label} Reference Range` &&
+      (annotation as BoxAnnotationOptions)?.label?.content === `${datasetLabel} Reference Range` &&
       typeof annotation.yMax === 'number' &&
       typeof annotation.yMin === 'number' &&
       typeof annotation.yScaleID === 'string'

--- a/projects/ngx-charts-on-fhir/src/lib/fhir-chart-summary/statistics.service.ts
+++ b/projects/ngx-charts-on-fhir/src/lib/fhir-chart-summary/statistics.service.ts
@@ -5,6 +5,7 @@ import { AnnotationOptions, BoxAnnotationOptions } from 'chartjs-plugin-annotati
 import { DataLayer, Dataset } from '../data-layer/data-layer';
 import { NumberRange, isValidScatterDataPoint, MILLISECONDS_PER_DAY, isDefined, ChartAnnotations } from '../utils';
 import { DeepPartial } from 'chart.js/dist/types/utils';
+import { getOriginalLabel } from './home-measurement-summary.service';
 
 type Stats = {
   days: number;
@@ -183,7 +184,7 @@ function getDay(point: ScatterDataPoint): string {
 
 /** Factory for generating functions that check if any given annotation is a reference range for the bound dataset */
 function isReferenceRangeFor(dataset: Dataset) {
-  const datasetLabel = dataset.label?.includes('(Home)') ? dataset.label.split('(Home)')[0].trim() : dataset.label;
+  const datasetLabel = getOriginalLabel(dataset);
   return function isReferenceRange(annotation: DeepPartial<AnnotationOptions>): annotation is ReferenceRange {
     return (
       (annotation as BoxAnnotationOptions)?.label?.content === `${datasetLabel} Reference Range` &&


### PR DESCRIPTION
## Overview
 - Fixed reference range tooltip issue for home measurement.
 - Add check for checking in dataset label `(Home)` is present or not.
 - If present then split it and pass it to the function.

![image](https://user-images.githubusercontent.com/117890382/229082800-5321d056-33ec-49c9-af69-1ea4079010c9.png)

## How it was tested

Tested using run all `charts-on-fhir` apps locally.

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [x] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
