### PR TITLE
RT-723-Range-selector-buttons-should-use-today-as-end-date

### DIFF
--- a/libs/ngx-charts-on-fhir/src/lib/range-selector/range-selector.component.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/range-selector/range-selector.component.spec.ts
@@ -13,8 +13,9 @@ import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatNativeDateModule } from '@angular/material/core';
 import { FormsModule } from '@angular/forms';
 import { FhirChartConfigurationService } from '../fhir-chart/fhir-chart-configuration.service';
+import { subtractMonths } from './range-selector.component';
 
-const max = new Date('2022-03-30T00:00').getTime();
+const max = new Date().getTime();
 const min = new Date('2022-01-06T00:00').getTime();
 
 class MockConfigService {
@@ -59,28 +60,28 @@ describe('RangeSelectorComponent', () => {
   it('should calculate proper 1 month ago date from max layer date', async () => {
     let ButtonInputGroup = await loader.getHarness(MatButtonToggleHarness.with({ selector: "[id='1 mo']" }));
     await ButtonInputGroup.check();
-    const expectedMinDate = new Date('2022-02-28T00:00');
+    const expectedMinDate = subtractMonths(component.maxDate!, 1);
     expect(component.minDate).toEqual(expectedMinDate);
   });
 
   it('should calculate proper 3 month ago date from max layer date', async () => {
     let ButtonInput = await loader.getHarness(MatButtonToggleHarness.with({ selector: "[id='3 mo']" }));
     await ButtonInput.check();
-    const expectedMinDate = new Date('2021-12-30T00:00');
+    const expectedMinDate = subtractMonths(component.maxDate!, 3);
     expect(component.minDate).toEqual(expectedMinDate);
   });
 
   it('should calculate proper 6 month ago date from max layer date', async () => {
     let ButtonInput = await loader.getHarness(MatButtonToggleHarness.with({ selector: "[id='6 mo']" }));
     await ButtonInput.check();
-    const expectedMinDate = new Date('2021-09-30T00:00');
+    const expectedMinDate = subtractMonths(component.maxDate!, 6);
     expect(component.minDate).toEqual(expectedMinDate);
   });
 
   it('should calculate proper 12 month ago date from max layer date', async () => {
     let ButtonInput = await loader.getHarness(MatButtonToggleHarness.with({ selector: "[id='1 y']" }));
     await ButtonInput.check();
-    const expectedMinDate = new Date('2021-03-30T00:00');
+    const expectedMinDate = subtractMonths(component.maxDate!, 12);
     expect(component.minDate).toEqual(expectedMinDate);
   });
 
@@ -112,8 +113,11 @@ describe('RangeSelectorComponent', () => {
   });
 
   it('should subscribe timelineRange when the component initializes and set minDate and maxDate', async () => {
-    expect(component.minDate).toEqual(new Date(min));
-    expect(component.maxDate).toEqual(new Date(max));
-    expect(component.selectedButton).toEqual(2);
+    const componentMindate = new Date(new Date(min).setHours(0, 0, 0, 0));
+    const componentMaxdate = new Date(new Date(max).setHours(0, 0, 0, 0));
+    expect(component.minDate?.toDateString()).toEqual(componentMindate.toDateString());
+    expect(component.maxDate?.toDateString()).toEqual(componentMaxdate.toDateString());
+    const months = component.calculateMonthDiff(componentMindate, componentMaxdate);
+    expect(component.selectedButton).toEqual(months);
   });
 });

--- a/libs/ngx-charts-on-fhir/src/lib/range-selector/range-selector.component.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/range-selector/range-selector.component.spec.ts
@@ -13,9 +13,8 @@ import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatNativeDateModule } from '@angular/material/core';
 import { FormsModule } from '@angular/forms';
 import { FhirChartConfigurationService } from '../fhir-chart/fhir-chart-configuration.service';
-import { subtractMonths } from './range-selector.component';
 
-const max = new Date().getTime();
+const max = new Date('2022-03-30T00:00').getTime();
 const min = new Date('2022-01-06T00:00').getTime();
 
 class MockConfigService {
@@ -58,30 +57,34 @@ describe('RangeSelectorComponent', () => {
   });
 
   it('should calculate proper 1 month ago date from max layer date', async () => {
+    jasmine.clock().mockDate(new Date('2023-04-13'));
     let ButtonInputGroup = await loader.getHarness(MatButtonToggleHarness.with({ selector: "[id='1 mo']" }));
     await ButtonInputGroup.check();
-    const expectedMinDate = subtractMonths(component.maxDate!, 1);
+    const expectedMinDate = new Date('2023-03-13');
     expect(component.minDate).toEqual(expectedMinDate);
   });
 
   it('should calculate proper 3 month ago date from max layer date', async () => {
+    jasmine.clock().mockDate(new Date('2023-04-13'));
     let ButtonInput = await loader.getHarness(MatButtonToggleHarness.with({ selector: "[id='3 mo']" }));
     await ButtonInput.check();
-    const expectedMinDate = subtractMonths(component.maxDate!, 3);
+    const expectedMinDate = new Date('2023-01-13');
     expect(component.minDate).toEqual(expectedMinDate);
   });
 
   it('should calculate proper 6 month ago date from max layer date', async () => {
+    jasmine.clock().mockDate(new Date('2023-04-13'));
     let ButtonInput = await loader.getHarness(MatButtonToggleHarness.with({ selector: "[id='6 mo']" }));
     await ButtonInput.check();
-    const expectedMinDate = subtractMonths(component.maxDate!, 6);
+    const expectedMinDate = new Date('2022-10-13');
     expect(component.minDate).toEqual(expectedMinDate);
   });
 
   it('should calculate proper 12 month ago date from max layer date', async () => {
+    jasmine.clock().mockDate(new Date('2023-04-13'));
     let ButtonInput = await loader.getHarness(MatButtonToggleHarness.with({ selector: "[id='1 y']" }));
     await ButtonInput.check();
-    const expectedMinDate = subtractMonths(component.maxDate!, 12);
+    const expectedMinDate = new Date('2022-04-13');
     expect(component.minDate).toEqual(expectedMinDate);
   });
 
@@ -113,11 +116,8 @@ describe('RangeSelectorComponent', () => {
   });
 
   it('should subscribe timelineRange when the component initializes and set minDate and maxDate', async () => {
-    const componentMindate = new Date(new Date(min).setHours(0, 0, 0, 0));
-    const componentMaxdate = new Date(new Date(max).setHours(0, 0, 0, 0));
-    expect(component.minDate?.toDateString()).toEqual(componentMindate.toDateString());
-    expect(component.maxDate?.toDateString()).toEqual(componentMaxdate.toDateString());
-    const months = component.calculateMonthDiff(componentMindate, componentMaxdate);
-    expect(component.selectedButton).toEqual(months);
+    expect(component.minDate).toEqual(new Date(min));
+    expect(component.maxDate).toEqual(new Date(max));
+    expect(component.selectedButton).toEqual(2);
   });
 });

--- a/libs/ngx-charts-on-fhir/src/lib/range-selector/range-selector.component.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/range-selector/range-selector.component.spec.ts
@@ -57,34 +57,34 @@ describe('RangeSelectorComponent', () => {
   });
 
   it('should calculate proper 1 month ago date from max layer date', async () => {
-    jasmine.clock().mockDate(new Date('2023-04-13'));
+    jasmine.clock().mockDate(new Date('2022-03-30T00:00'));
     let ButtonInputGroup = await loader.getHarness(MatButtonToggleHarness.with({ selector: "[id='1 mo']" }));
     await ButtonInputGroup.check();
-    const expectedMinDate = new Date('2023-03-13');
+    const expectedMinDate = new Date('2022-02-28T00:00');
     expect(component.minDate).toEqual(expectedMinDate);
   });
 
   it('should calculate proper 3 month ago date from max layer date', async () => {
-    jasmine.clock().mockDate(new Date('2023-04-13'));
+    jasmine.clock().mockDate(new Date('2022-03-30T00:00'));
     let ButtonInput = await loader.getHarness(MatButtonToggleHarness.with({ selector: "[id='3 mo']" }));
     await ButtonInput.check();
-    const expectedMinDate = new Date('2023-01-13');
+    const expectedMinDate = new Date('2021-12-30T00:00');
     expect(component.minDate).toEqual(expectedMinDate);
   });
 
   it('should calculate proper 6 month ago date from max layer date', async () => {
-    jasmine.clock().mockDate(new Date('2023-04-13'));
+    jasmine.clock().mockDate(new Date('2022-03-30T00:00'));
     let ButtonInput = await loader.getHarness(MatButtonToggleHarness.with({ selector: "[id='6 mo']" }));
     await ButtonInput.check();
-    const expectedMinDate = new Date('2022-10-13');
+    const expectedMinDate = new Date('2021-09-30T00:00');
     expect(component.minDate).toEqual(expectedMinDate);
   });
 
   it('should calculate proper 12 month ago date from max layer date', async () => {
-    jasmine.clock().mockDate(new Date('2023-04-13'));
+    jasmine.clock().mockDate(new Date('2022-03-30T00:00'));
     let ButtonInput = await loader.getHarness(MatButtonToggleHarness.with({ selector: "[id='1 y']" }));
     await ButtonInput.check();
-    const expectedMinDate = new Date('2022-04-13');
+    const expectedMinDate = new Date('2021-03-30T00:00');
     expect(component.minDate).toEqual(expectedMinDate);
   });
 

--- a/libs/ngx-charts-on-fhir/src/lib/range-selector/range-selector.component.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/range-selector/range-selector.component.ts
@@ -27,7 +27,7 @@ export class RangeSelectorComponent {
 
   ngOnInit(): void {
     this.configService.timelineRange$.pipe(delay(0)).subscribe((timelineRange) => {
-      this.maxDate = new Date();
+      this.maxDate = new Date(timelineRange.max);
       this.minDate = new Date(timelineRange.min);
       if (this.configService.isAutoZoom) {
         this.selectedButton = 'All';
@@ -40,10 +40,11 @@ export class RangeSelectorComponent {
 
   updateRangeSelector(monthCount: number) {
     if (this.maxDate && monthCount) {
+      this.maxDate = new Date();
       this.minDate = subtractMonths(this.maxDate, monthCount);
       this.configService.zoom({
         min: this.minDate.getTime(),
-        max: this.maxDate.getTime(),
+        max: new Date().getTime(),
       });
     }
   }
@@ -78,7 +79,7 @@ export class RangeSelectorComponent {
   }
 }
 
-export function subtractMonths(oldDate: Date, months: number): Date {
+function subtractMonths(oldDate: Date, months: number): Date {
   const newDate = new Date(oldDate);
   newDate.setMonth(oldDate.getMonth() - months);
   // If day-of-the-month (getDate) has changed, it's because the day did not exist

--- a/libs/ngx-charts-on-fhir/src/lib/range-selector/range-selector.component.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/range-selector/range-selector.component.ts
@@ -27,7 +27,7 @@ export class RangeSelectorComponent {
 
   ngOnInit(): void {
     this.configService.timelineRange$.pipe(delay(0)).subscribe((timelineRange) => {
-      this.maxDate = new Date(timelineRange.max);
+      this.maxDate = new Date();
       this.minDate = new Date(timelineRange.min);
       if (this.configService.isAutoZoom) {
         this.selectedButton = 'All';
@@ -78,7 +78,7 @@ export class RangeSelectorComponent {
   }
 }
 
-function subtractMonths(oldDate: Date, months: number): Date {
+export function subtractMonths(oldDate: Date, months: number): Date {
   const newDate = new Date(oldDate);
   newDate.setMonth(oldDate.getMonth() - months);
   // If day-of-the-month (getDate) has changed, it's because the day did not exist


### PR DESCRIPTION
## Overview

- updated code for range selector buttons to use today as the end date.
- updated test cases.

## How it was tested
-Tested it by launching showcase, Cardiovascular Health, and cardio-patient locally.
-Ran unit test locally.


## Checklist

- [X] The title contains a short meaningful summary
- [X] I have added a link to this PR in the Jira issue
- [X] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [X] I have updated unit tests
- [X] I have run unit tests locally
- [ ] I have updated documentation (including README)
