### PR TITLE
RT-722:Medications graph should be called "Medication Prescriptions"

### DIFF
--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/medication-summary.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/medication-summary.service.spec.ts
@@ -47,7 +47,7 @@ describe('MedicationSummaryService', () => {
       const summary = summaryService.summarize(layer);
       expect(summary).toEqual([
         {
-          Medications: 'one',
+          'Medication Prescriptions': 'one',
           'Date Written': '1 Jan 2023',
         },
       ]);

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/medication-summary.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/medication-summary.service.ts
@@ -13,7 +13,7 @@ export class MedicationSummaryService implements SummaryService {
   }
   summarize(layer: DataLayer<TimelineChartType, MedicationDataPoint[]>): Record<string, string>[] {
     return layer.datasets.map((dataset) => ({
-      [layer.name]: dataset.label ?? '(unknown)',
+      'Medication Prescriptions': dataset.label ?? '(unknown)',
       'Date Written': formatDate(Math.max(...dataset.data.map((point) => point.authoredOn))),
     }));
   }


### PR DESCRIPTION
## Overview

Change the medication summary table title medication to `Medication Prescriptions`.
Update the test cases according to changes.
 
## How it was tested
Tested using run showcase and cardio-health app locally.


## Checklist

- [ ] The title contains a short meaningful summary
- [ ] I have added a link to this PR in the Jira issue
- [ ] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)
