### PR TITLE
RT-742-End date resets to previous value when changing layer options

### DIFF
--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.ts
@@ -127,13 +127,13 @@ export class FhirChartConfigurationService {
           annotation: { annotations: [...annotations, this.todayDateVerticalLineAnnotation] },
           zoom: {
             zoom: {
-              onZoomStart: ({ chart }) => {
+              onZoomComplete: ({ chart }) => {
                 this.lockZoomRange(chart.scales['x']);
                 return true;
               },
             },
             pan: {
-              onPanStart: ({ chart }) => {
+              onPanComplete: ({ chart }) => {
                 this.lockZoomRange(chart.scales['x']);
                 return true;
               },


### PR DESCRIPTION
## Overview
In `FhirChartConfigurationService`  change the onZoomStart and onPanStart callbacks to onZoomComplete and onPanComplete callbacks.

## How it was tested
Tested using run all `charts-on-fhir` locally.


## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [x] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
