### PR TITLE
ScaleStackDivider assumes a white background

### DIFF
--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart/scale-stack-divider-plugin.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart/scale-stack-divider-plugin.spec.ts
@@ -10,7 +10,7 @@ describe('scaleStackDividerPlugin', () => {
   it('should draw a line between scales', () => {
     const ctx = jasmine.createSpyObj<CanvasRenderingContext2D>(
       'CanvasRenderingContext2D',
-      ['save', 'restore', 'beginPath', 'moveTo', 'lineTo', 'stroke'],
+      ['save', 'restore', 'beginPath', 'moveTo', 'lineTo', 'stroke', 'clearRect'],
       ['strokeStyle', 'lineWidth']
     );
     const chartArea: ChartArea = {
@@ -38,6 +38,7 @@ describe('scaleStackDividerPlugin', () => {
     if (scaleStackDividerPlugin.beforeDatasetsDraw) {
       scaleStackDividerPlugin.beforeDatasetsDraw(chart, { cancelable: true }, {});
     }
+    expect(ctx.clearRect).toHaveBeenCalled();
     expect(ctx.stroke).toHaveBeenCalled();
   });
 });

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart/scale-stack-divider-plugin.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart/scale-stack-divider-plugin.ts
@@ -8,7 +8,7 @@ export const scaleStackDividerPlugin: Plugin = {
     for (let scale of Object.values(chart.scales)) {
       if (!scale.isHorizontal() && isCartesianScale(scale) && scale.top > chartArea.top) {
         ctx.save();
-        drawDivider(chart, scale, 24, '#fff');
+        ctx.clearRect(chart.chartArea.left - 1, scale.top - 12, chart.chartArea.width, 24);
         drawDivider(chart, scale, 1, '#666');
         ctx.restore();
       }


### PR DESCRIPTION
## Overview

- updated scaleStackDividerPlugin to use clearRect() instead of drawing a white line

## How it was tested

- ran showcase app locally and set a non-white background color using chrome devtools

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [x] I have included screen shots for changes that affect the user interface
- [x] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
