### PR TITLE
RT-739-Hide-Glucose-by-default

### DIFF
--- a/apps/cardiovascular-health/src/app/app.component.ts
+++ b/apps/cardiovascular-health/src/app/app.component.ts
@@ -10,11 +10,11 @@ export class AppComponent implements OnInit {
   showAddDataLayer: boolean = false;
   layers: any[] = [];
   isAllLayerSelected = true;
-
+  preDisableLayer: string[] = ['Glucose'];
   constructor(readonly layerManager: DataLayerManagerService) {}
 
   ngOnInit(): void {
-    this.layerManager.retrieveAll(this.isAllLayerSelected, this.sortCompareFn);
+    this.layerManager.retrieveAll(this.isAllLayerSelected, this.sortCompareFn, this.preDisableLayer);
   }
 
   sortCompareFn = (a: DataLayer, b: DataLayer) => {

--- a/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-manager.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-manager.service.spec.ts
@@ -67,6 +67,23 @@ describe('DataLayerManagerService', () => {
       );
     });
 
+    it('should disable layer when we pass particular layer to disable', () => {
+      const preDisableLayer: string[] = ['a'];
+      const services = [
+        { name: 'one', retrieve: () => cold('c-b|', { c, b }) },
+        { name: 'two', retrieve: () => cold('-a|', { a }) },
+      ];
+      const manager = new DataLayerManagerService(services, colorService, tagsService, mergeService);
+      manager.retrieveAll(true, (one, two) => one.name.localeCompare(two.name), preDisableLayer);
+      expect(manager.selectedLayers$).toBeObservable(
+        hot('xyz', {
+          x: [jasmine.objectContaining(c)],
+          y: [jasmine.objectContaining({ enabled: false }), jasmine.objectContaining(c)],
+          z: [jasmine.objectContaining({ enabled: false }), jasmine.objectContaining(b), jasmine.objectContaining(c)],
+        })
+      );
+    });
+
     it('should sort selectedLayers$ when auto-selecting', () => {
       const services = [
         { name: 'one', retrieve: () => cold('c-b|', { c, b }) },

--- a/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-manager.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-manager.service.ts
@@ -116,7 +116,7 @@ export class DataLayerManagerService {
    * @param selectAll When `true`, every layer that is retrieved will be automatically selected.
    * @param sortCompareFn A comparison function for sorting auto-selected layers. This function will be passed to `Array.sort`.
    */
-  retrieveAll(selectAll: boolean = false, sortCompareFn: LayerCompareFn = () => 0) {
+  retrieveAll(selectAll: boolean = false, sortCompareFn: LayerCompareFn = () => 0, preDisableLayer: string[] = []) {
     this.reset();
     this.loading$.next(true);
     merge(...this.dataLayerServices.map((service) => service.retrieve()))
@@ -126,7 +126,7 @@ export class DataLayerManagerService {
           const layers = this.mergeService.merge(this.state.layers, layer);
           let nextState = { ...this.stateSubject.value, layers };
           if (selectAll) {
-            nextState = this.selectAllLayers(nextState);
+            nextState = this.selectAllLayers(nextState, preDisableLayer);
             nextState = this.sortLayers(nextState, sortCompareFn);
           }
           this.stateSubject.next(nextState);
@@ -144,17 +144,22 @@ export class DataLayerManagerService {
   });
 
   /** Reducer that returns a new state with all layers selected */
-  private selectAllLayers = (state: DataLayerManagerState) => {
-    return Object.keys(state.layers).reduce((nextState, id) => this.selectLayer(nextState, id), state);
+  private selectAllLayers = (state: DataLayerManagerState, preDisableLayer: string[]) => {
+    return Object.keys(state.layers).reduce((nextState, id) => this.selectLayer(nextState, id, preDisableLayer), state);
   };
 
   /** Reducer that returns a new state with the given layer selected */
-  private selectLayer = produce<DataLayerManagerState, [string]>((draft, id) => {
+  private selectLayer = produce<DataLayerManagerState, [string, string[]?]>((draft, id, preDisableLayer: string[] = []) => {
     if (!draft.layers[id].selected) {
       const layer = draft.layers[id];
       draft.selected.push(layer.id);
       layer.selected = true;
       layer.enabled = true;
+      preDisableLayer.forEach((layerName: any) => {
+        if (layerName === layer.name) {
+          layer.enabled = false;
+        }
+      });
       this.colorService.chooseColorsFromPalette(layer);
       for (let dataset of layer.datasets) {
         this.tagsService.applyTagStyles(dataset);

--- a/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-manager.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-manager.service.ts
@@ -155,7 +155,7 @@ export class DataLayerManagerService {
       draft.selected.push(layer.id);
       layer.selected = true;
       layer.enabled = true;
-      preDisableLayer.forEach((layerName: any) => {
+      preDisableLayer.forEach((layerName: string) => {
         if (layerName === layer.name) {
           layer.enabled = false;
         }


### PR DESCRIPTION
## Overview
-Updated data-layer-manger service to hide glucose by default.
-Now glucose is hidden by default if we click on the glucose checkbox it will display.

## How it was tested
-Tested by launching cardiovascular-health, cardio-patient, and showcase locally.
-Ran unit test locally.


## Checklist

- [X] The title contains a short meaningful summary
- [X] I have added a link to this PR in the Jira issue
- [X] I have described how this was tested
- [X] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [X] I have run unit tests locally
- [ ] I have updated documentation (including README)
![image](https://user-images.githubusercontent.com/57406228/233629572-2846322c-a1a0-4595-89ad-b39b5e919e27.png)
