### PR TITLE
Responsive summary cards with no scrolling

### DIFF
--- a/apps/cardiovascular-health/src/app/app.component.html
+++ b/apps/cardiovascular-health/src/app/app.component.html
@@ -5,6 +5,6 @@
     <ng-template #legend>
       <fhir-chart-tags-legend></fhir-chart-tags-legend>
     </ng-template>
-    <fhir-chart-summary class="layout-main-summary"></fhir-chart-summary>
+    <fhir-chart-summary class="layout-main-summary" [autoAlign]="true"></fhir-chart-summary>
   </div>
 </fhir-chart-layout>

--- a/apps/cardiovascular-health/src/app/app.component.scss
+++ b/apps/cardiovascular-health/src/app/app.component.scss
@@ -1,7 +1,7 @@
 .layout-main {
   display: grid;
-  grid-template-columns: auto max-content;
-  grid-template-rows: max-content auto;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto 1fr;
   padding: 8px;
   gap: 8px;
   height: 100vh;

--- a/apps/cardiovascular-patient-app/src/app/app.component.scss
+++ b/apps/cardiovascular-patient-app/src/app/app.component.scss
@@ -1,7 +1,7 @@
 .layout-main {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  grid-template-rows: auto max-content;
+  grid-template-rows: 1fr auto;
   grid-column-gap: 4px;
   height: calc(100vh - 108px);
 }

--- a/apps/cardiovascular-patient-app/src/app/app.component.ts
+++ b/apps/cardiovascular-patient-app/src/app/app.component.ts
@@ -16,11 +16,7 @@ export class AppComponent implements OnInit {
   constructor(readonly layerManager: DataLayerManagerService, private configService: FhirChartConfigurationService) {}
 
   ngOnInit(): void {
-    this.layerManager.retrieveAll();
-
-    this.layerManager.availableLayers$.subscribe((layers) => {
-      layers.forEach((layer) => this.layerManager.select(layer.id));
-    });
+    this.layerManager.retrieveAll(true);
 
     const now = new Date().getTime();
     this.configService.zoom({
@@ -30,7 +26,7 @@ export class AppComponent implements OnInit {
   }
 
   getBpLayerdata() {
-    this.layerManager.retrieveAll();
+    this.layerManager.retrieveAll(true);
     this.selectedIndex = 1;
   }
 }

--- a/apps/documentation/src/app/pages/components/chart-summary/demo/chart-summary-demo.component.html
+++ b/apps/documentation/src/app/pages/components/chart-summary/demo/chart-summary-demo.component.html
@@ -1,4 +1,4 @@
 <div class="example-container">
-  <fhir-chart width="600px" height="480px"></fhir-chart>
-  <fhir-chart-summary></fhir-chart-summary>
+  <fhir-chart width="100%" height="100%"></fhir-chart>
+  <fhir-chart-summary [autoAlign]="true"></fhir-chart-summary>
 </div>

--- a/apps/documentation/src/app/pages/components/chart-summary/demo/chart-summary-demo.css
+++ b/apps/documentation/src/app/pages/components/chart-summary/demo/chart-summary-demo.css
@@ -1,5 +1,6 @@
 .example-container {
-  height: 480px;
-  display: flex;
-  gap: 8px;
+  height: 320px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  padding: 6px;
 }

--- a/apps/documentation/src/app/pages/components/chart-summary/index.md
+++ b/apps/documentation/src/app/pages/components/chart-summary/index.md
@@ -4,6 +4,16 @@
 
 A stack of summary cards that display information about each data layer on the chart. The summary information will be updated dynamically to reflect the data points that are currently visible on the chart. If a summary card gets too small to display all of the content, it can be expanded to full size by clicking on it.
 
+## Inputs
+
+| Name      | Type      | Default | Description                                                                                  |
+| --------- | --------- | ------- | -------------------------------------------------------------------------------------------- |
+| autoAlign | `boolean` | `false` | If set to `true`, each summary card will be vertically aligned with the corresponding chart. |
+
+When `autoAlign` is set to `true`, the height of each card is determined by the height of the corresponding chart.
+This should only be used when the chart and summary components are used in a horizontal layout.
+If the chart and summary are arranged vertically, `autoAlign` should be set to false.
+
 ## Example
 
 {{ NgDocActions.demo("ChartSummaryDemoComponent", { expanded: true, defaultTab: "HTML" }) }}

--- a/apps/documentation/src/app/pages/components/chart-summary/index.md
+++ b/apps/documentation/src/app/pages/components/chart-summary/index.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-A stack of summary cards that display information about each data layer on the chart. The summary information will be updated dynamically to reflect the data points that are currently visible on the chart.
+A stack of summary cards that display information about each data layer on the chart. The summary information will be updated dynamically to reflect the data points that are currently visible on the chart. If a summary card gets too small to display all of the content, it can be expanded to full size by clicking on it.
 
 ## Example
 

--- a/apps/showcase/src/app/app.component.html
+++ b/apps/showcase/src/app/app.component.html
@@ -5,6 +5,6 @@
     <ng-template #legend>
       <fhir-chart-tags-legend></fhir-chart-tags-legend>
     </ng-template>
-    <fhir-chart-summary class="layout-main-summary"></fhir-chart-summary>
+    <fhir-chart-summary class="layout-main-summary" [autoAlign]="true"></fhir-chart-summary>
   </div>
 </fhir-chart-layout>

--- a/apps/showcase/src/app/app.component.scss
+++ b/apps/showcase/src/app/app.component.scss
@@ -1,7 +1,7 @@
 .layout-main {
   display: grid;
-  grid-template-columns: auto max-content;
-  grid-template-rows: max-content auto;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto 1fr;
   padding: 8px;
   gap: 8px;
   height: 100vh;

--- a/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-manager.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-manager.service.ts
@@ -6,6 +6,7 @@ import { DataLayerMergeService } from './data-layer-merge.service';
 import produce, { castDraft } from 'immer';
 import { zip } from 'lodash-es';
 import { FhirChartTagsService } from '../fhir-chart-legend/fhir-chart-tags-legend/fhir-chart-tags.service';
+import { CartesianScaleOptions } from 'chart.js';
 
 /**
  * A service for asynchronously retrieving data layers.
@@ -50,11 +51,16 @@ export abstract class DataLayerService {
 type DataLayerManagerState = {
   layers: DataLayerCollection;
   selected: string[];
+  focused: null | {
+    id: string;
+    originalWeight: number;
+  };
 };
 
 const initialState: DataLayerManagerState = {
   layers: {},
   selected: [],
+  focused: null,
 };
 
 type LayerCompareFn = (a: DataLayer, b: DataLayer) => number;
@@ -214,6 +220,39 @@ export class DataLayerManagerService {
       })
     );
   }
+
+  /** Focus a layer so it takes up a larger portion of the screen */
+  focus(id: string, height: number) {
+    if (!this.state.layers[id]) {
+      throw new Error(`Layer [${id}] not found`);
+    }
+    let nextState = this.unfocusLayer(this.state);
+    if (!this.state.focused || this.state.focused.id !== id) {
+      nextState = this.focusLayer(nextState, id, height);
+    }
+    this.stateSubject.next(nextState);
+  }
+
+  /** Reducer that returns a new state with the given layer focused */
+  private focusLayer = produce<DataLayerManagerState, [string, number]>((draft, id, height) => {
+    const layer = draft.layers[id];
+    const scale = layer.scale as CartesianScaleOptions;
+    const originalWeight = scale?.stackWeight ?? 1;
+    draft.focused = { id, originalWeight };
+    scale.stackWeight = (1.2 + 0.3 * draft.selected.length) * originalWeight;
+    layer.focused = true;
+  });
+
+  /** Reducer that returns a new state without a focused layer */
+  private unfocusLayer = produce<DataLayerManagerState>((draft) => {
+    if (draft.focused) {
+      const prevLayer = draft.layers[draft.focused.id];
+      const prevScale = prevLayer.scale as CartesianScaleOptions;
+      prevScale.stackWeight = draft.focused.originalWeight;
+      prevLayer.focused = false;
+      draft.focused = null;
+    }
+  });
 
   /** Modify a layer's properties.
    * This method must be used to propagate the changes to other components.

--- a/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer.ts
@@ -40,6 +40,7 @@ export type ManagedDataLayer = DataLayer & {
   id: string;
   selected?: boolean;
   enabled?: boolean;
+  focused?: boolean;
 };
 
 export type DataLayerCollection = { [id: string]: ManagedDataLayer };

--- a/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer.ts
@@ -40,7 +40,6 @@ export type ManagedDataLayer = DataLayer & {
   id: string;
   selected?: boolean;
   enabled?: boolean;
-  focused?: boolean;
 };
 
 export type DataLayerCollection = { [id: string]: ManagedDataLayer };

--- a/libs/ngx-charts-on-fhir/src/lib/dynamic-table/dynamic-table.component.css
+++ b/libs/ngx-charts-on-fhir/src/lib/dynamic-table/dynamic-table.component.css
@@ -1,18 +1,30 @@
-table {
+.grid-table {
+  display: grid;
   width: 100%;
+  height: 100%;
+  grid-auto-rows: minmax(auto, 36px);
+  align-items: stretch;
 }
 
-td.mat-mdc-cell,
-th.mat-mdc-header-cell {
+.grid-thead,
+.grid-tbody {
+  display: contents;
+}
+.grid-th {
+  font-weight: 500;
+}
+.grid-th,
+.grid-td {
+  display: flex;
+  justify-content: end;
   text-align: end;
-  justify-content: flex-end;
+  align-items: center;
   white-space: nowrap;
-  padding-right: 8px;
-  padding-left: 8px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+  padding: 0px 8px;
 }
-
-td.mat-mdc-cell:first-child,
-th.mat-mdc-header-cell:first-child {
-  text-align: left;
-  justify-content: flex-start;
+.grid-th:first-child,
+.grid-td:first-child {
+  justify-content: start;
+  text-align: start;
 }

--- a/libs/ngx-charts-on-fhir/src/lib/dynamic-table/dynamic-table.component.html
+++ b/libs/ngx-charts-on-fhir/src/lib/dynamic-table/dynamic-table.component.html
@@ -1,4 +1,4 @@
-<div class="grid-table" [style.gridTemplateColumns]="'repeat(' + columns.length + ', 1fr)'">
+<div class="grid-table" [style.gridTemplateColumns]="'repeat(' + columns.length + ', auto)'">
   <div class="grid-thead">
     <div class="grid-th" *ngFor="let col of columns">{{ col | titlecase }}</div>
   </div>

--- a/libs/ngx-charts-on-fhir/src/lib/dynamic-table/dynamic-table.component.html
+++ b/libs/ngx-charts-on-fhir/src/lib/dynamic-table/dynamic-table.component.html
@@ -1,8 +1,8 @@
-<table mat-table [dataSource]="data" aria-label="Summary">
-  <ng-container *ngFor="let col of columns" [matColumnDef]="col">
-    <th mat-header-cell *matHeaderCellDef>{{ col | titlecase }}</th>
-    <td mat-cell *matCellDef="let element">{{ element[col] }}</td>
-  </ng-container>
-  <tr mat-header-row *matHeaderRowDef="columns"></tr>
-  <tr mat-row *matRowDef="let row; columns: columns"></tr>
-</table>
+<div class="grid-table" [style.gridTemplateColumns]="'repeat(' + columns.length + ', 1fr)'">
+  <div class="grid-thead">
+    <div class="grid-th" *ngFor="let col of columns">{{ col | titlecase }}</div>
+  </div>
+  <div class="grid-tbody" *ngFor="let row of _data">
+    <div class="grid-td" *ngFor="let col of columns">{{ row[col] }}</div>
+  </div>
+</div>

--- a/libs/ngx-charts-on-fhir/src/lib/dynamic-table/dynamic-table.component.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/dynamic-table/dynamic-table.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatTableModule } from '@angular/material/table';
 import { DynamicTableComponent } from './dynamic-table.component';
+import { By } from '@angular/platform-browser';
 
 describe('DynamicTableComponent', () => {
   let component: DynamicTableComponent;
@@ -9,7 +9,6 @@ describe('DynamicTableComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [DynamicTableComponent],
-      imports: [MatTableModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(DynamicTableComponent);
@@ -19,5 +18,81 @@ describe('DynamicTableComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('when data is an array of records', () => {
+    it('should render column headings in title case', async () => {
+      fixture.componentRef.setInput('data', [
+        { 'col one': '0', 'col two': '1' },
+        { 'col one': '2', 'col two': '3' },
+      ]);
+      fixture.detectChanges();
+      const th = fixture.debugElement.queryAll(By.css('.grid-th'));
+      expect(th[0].nativeElement.textContent).toBe('Col One');
+      expect(th[1].nativeElement.textContent).toBe('Col Two');
+    });
+
+    it('should render grid items', async () => {
+      fixture.componentRef.setInput('data', [
+        { a: '0', b: '1' },
+        { a: '2', b: '3' },
+      ]);
+      fixture.detectChanges();
+      const td = fixture.debugElement.queryAll(By.css('.grid-td'));
+      expect(td[0].nativeElement.textContent).toBe('0');
+      expect(td[1].nativeElement.textContent).toBe('1');
+      expect(td[2].nativeElement.textContent).toBe('2');
+      expect(td[3].nativeElement.textContent).toBe('3');
+    });
+
+    it('should set grid-template-columns to the correct number of columns', () => {
+      fixture.componentRef.setInput('data', [
+        { a: '0', b: '1' },
+        { a: '2', b: '3' },
+      ]);
+      fixture.detectChanges();
+
+      const table = fixture.debugElement.query(By.css('.grid-table'));
+      expect(table.styles['gridTemplateColumns']).toBe('repeat(2, auto)');
+    });
+  });
+
+  describe('when data is a 2D array', () => {
+    it('should render column headings in title case', async () => {
+      fixture.componentRef.setInput('data', [
+        ['col one', 'col two'],
+        [0, 1],
+        [2, 3],
+      ]);
+      fixture.detectChanges();
+      const th = fixture.debugElement.queryAll(By.css('.grid-th'));
+      expect(th[0].nativeElement.textContent).toBe('Col One');
+      expect(th[1].nativeElement.textContent).toBe('Col Two');
+    });
+
+    it('should render grid items', async () => {
+      fixture.componentRef.setInput('data', [
+        ['a', 'b'],
+        ['0', '1'],
+        ['2', '3'],
+      ]);
+      fixture.detectChanges();
+      const td = fixture.debugElement.queryAll(By.css('.grid-td'));
+      expect(td[0].nativeElement.textContent).toBe('0');
+      expect(td[1].nativeElement.textContent).toBe('1');
+      expect(td[2].nativeElement.textContent).toBe('2');
+      expect(td[3].nativeElement.textContent).toBe('3');
+    });
+
+    it('should set grid-template-columns to the correct number of columns', () => {
+      fixture.componentRef.setInput('data', [
+        ['a', 'b'],
+        ['0', '1'],
+        ['2', '3'],
+      ]);
+      fixture.detectChanges();
+      const table = fixture.debugElement.query(By.css('.grid-table'));
+      expect(table.styles['gridTemplateColumns']).toBe('repeat(2, auto)');
+    });
   });
 });

--- a/libs/ngx-charts-on-fhir/src/lib/dynamic-table/dynamic-table.component.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/dynamic-table/dynamic-table.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input } from '@angular/core';
+import { zipObject } from 'lodash-es';
 
 @Component({
   selector: 'dynamic-table',
@@ -6,8 +7,19 @@ import { Component, Input } from '@angular/core';
   styleUrls: ['./dynamic-table.component.css'],
 })
 export class DynamicTableComponent {
-  @Input() data: Record<string, string>[] = [{}];
-  get columns() {
-    return Object.keys(this.data[0]);
+  columns: string[] = [];
+  _data: Record<string, string>[] = [];
+  @Input() set data(inputData: Record<string, string>[] | string[][]) {
+    if (isArrayData(inputData)) {
+      this._data = inputData.slice(1).map((row) => zipObject(inputData[0], row));
+      this.columns = inputData[0];
+    } else {
+      this._data = inputData;
+      this.columns = Object.keys(this._data[0]);
+    }
   }
+}
+
+function isArrayData(data: Record<string, string>[] | string[][]): data is string[][] {
+  return Array.isArray(data[0]);
 }

--- a/libs/ngx-charts-on-fhir/src/lib/dynamic-table/dynamic-table.component.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/dynamic-table/dynamic-table.component.ts
@@ -1,10 +1,11 @@
-import { Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { zipObject } from 'lodash-es';
 
 @Component({
   selector: 'dynamic-table',
   templateUrl: './dynamic-table.component.html',
   styleUrls: ['./dynamic-table.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DynamicTableComponent {
   columns: string[] = [];

--- a/libs/ngx-charts-on-fhir/src/lib/dynamic-table/dynamic-table.component.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/dynamic-table/dynamic-table.component.ts
@@ -10,6 +10,11 @@ import { zipObject } from 'lodash-es';
 export class DynamicTableComponent {
   columns: string[] = [];
   _data: Record<string, string>[] = [];
+  /**
+   * Input data can be an array of records or a 2D array.
+   * If it is an array of records, the record keys will be the column headings.
+   * If it is a 2D array, the first row will be column headings.
+   * */
   @Input() set data(inputData: Record<string, string>[] | string[][]) {
     if (isArrayData(inputData)) {
       this._data = inputData.slice(1).map((row) => zipObject(inputData[0], row));

--- a/libs/ngx-charts-on-fhir/src/lib/dynamic-table/dynamic-table.module.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/dynamic-table/dynamic-table.module.ts
@@ -1,11 +1,10 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MatTableModule } from '@angular/material/table';
 import { DynamicTableComponent } from './dynamic-table.component';
 
 @NgModule({
   declarations: [DynamicTableComponent],
-  imports: [CommonModule, MatTableModule],
+  imports: [CommonModule],
   exports: [DynamicTableComponent],
 })
 export class DynamicTableModule {}

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary-card/fhir-chart-summary-card.component.css
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary-card/fhir-chart-summary-card.component.css
@@ -1,4 +1,22 @@
 .summary-card {
   border-left: 4px solid transparent;
-  min-height: 100%;
+  height: 100%;
+  width: 100%;
+}
+.overlay {
+  width: 100%;
+  align-self: stretch;
+  justify-self: stretch;
+}
+.overlay-origin {
+  width: 100%;
+  height: 100%;
+  position: relative;
+}
+.content-overflow {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 100%);
+  position: absolute;
+  width: 100%;
+  bottom: 0px;
+  height: 16px;
 }

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary-card/fhir-chart-summary-card.component.html
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary-card/fhir-chart-summary-card.component.html
@@ -1,3 +1,28 @@
-<div class="card summary-card" [style.background]="getBackgroundStyle()">
-  <ng-content></ng-content>
-</div>
+<ng-container *ngIf="configService.timelineRange$ | async as range">
+  <ng-template #template>
+    <div class="card summary-card" [style.background]="getBackgroundStyle()">
+      <dynamic-table [data]="summarize(range)"></dynamic-table>
+    </div>
+  </ng-template>
+  <div class="overlay-origin" cdkOverlayOrigin #trigger="cdkOverlayOrigin" (click)="expanded = true" [matTooltip]="getTooltip()">
+    <ng-container [ngTemplateOutlet]="template"></ng-container>
+    <div *ngIf="contentOverflow" class="content-overflow"></div>
+  </div>
+  <ng-template
+    cdkConnectedOverlay
+    [cdkConnectedOverlayOpen]="expanded"
+    [cdkConnectedOverlayOrigin]="trigger"
+    [cdkConnectedOverlayHasBackdrop]="false"
+    cdkConnectedOverlayPanelClass="mat-elevation-z4"
+    [cdkConnectedOverlayPositions]="overlayPositions"
+    [cdkConnectedOverlayPush]="true"
+    [cdkConnectedOverlayGrowAfterOpen]="true"
+    [cdkConnectedOverlayWidth]="collapsedWidth + 16"
+    [cdkConnectedOverlayMinHeight]="collapsedHeight"
+    (detach)="expanded = false"
+  >
+    <div class="overlay" (click)="expanded = false">
+      <ng-container [ngTemplateOutlet]="template"></ng-container>
+    </div>
+  </ng-template>
+</ng-container>

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary-card/fhir-chart-summary-card.component.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary-card/fhir-chart-summary-card.component.spec.ts
@@ -11,11 +11,6 @@ import { FhirChartConfigurationService } from '../../fhir-chart/fhir-chart-confi
 import { OverlayModule } from '@angular/cdk/overlay';
 import { MatTooltipModule } from '@angular/material/tooltip';
 
-const mockColorService = {
-  getColor: () => '#000000',
-  setColor: () => {},
-};
-
 class MockConfigService {
   timelineRange$ = new BehaviorSubject<NumberRange>({ min: 0, max: 10 });
 }

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary-card/fhir-chart-summary-card.component.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary-card/fhir-chart-summary-card.component.spec.ts
@@ -65,4 +65,22 @@ describe('FhirChartSummaryCardComponent', () => {
     const statistics: DebugElement = fixture.debugElement.query(By.directive(MockDynamicTableComponent));
     expect(statistics.componentInstance.data).toEqual([{ name: 'summary' }]);
   });
+
+  it('should show overlay when card is expanded', () => {
+    const layer: ManagedDataLayer = { id: '1', name: 'layer', datasets: [{ label: 'dataset', data: [] }], scale: { id: 'test' } };
+    component.layer = layer;
+    component.expanded = true;
+    fixture.detectChanges();
+    const overlay: DebugElement = fixture.debugElement.query(By.css('.overlay'));
+    expect(overlay).toBeDefined();
+  });
+
+  it('should hide overlay when card is collapsed', () => {
+    const layer: ManagedDataLayer = { id: '1', name: 'layer', datasets: [{ label: 'dataset', data: [] }], scale: { id: 'test' } };
+    component.layer = layer;
+    component.expanded = false;
+    fixture.detectChanges();
+    const overlay: DebugElement = fixture.debugElement.query(By.css('.overlay'));
+    expect(overlay).toBeNull();
+  });
 });

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary-card/fhir-chart-summary-card.component.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary-card/fhir-chart-summary-card.component.spec.ts
@@ -1,24 +1,50 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatCardModule } from '@angular/material/card';
-import { MatIconModule } from '@angular/material/icon';
 import { DataLayerColorService, COLOR_PALETTE } from '../../data-layer/data-layer-color.service';
 import { FhirChartSummaryCardComponent } from './fhir-chart-summary-card.component';
+import { Component, Input, DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { ManagedDataLayer } from '../../data-layer/data-layer';
+import { BehaviorSubject } from 'rxjs';
+import { NumberRange } from '../../utils';
+import { SummaryService } from '../summary.service';
+import { FhirChartConfigurationService } from '../../fhir-chart/fhir-chart-configuration.service';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 const mockColorService = {
   getColor: () => '#000000',
   setColor: () => {},
 };
 
+class MockConfigService {
+  timelineRange$ = new BehaviorSubject<NumberRange>({ min: 0, max: 10 });
+}
+
+@Component({ selector: 'dynamic-table', template: '' })
+class MockDynamicTableComponent {
+  @Input() data: Record<string, string>[] = [];
+}
+
 describe('FhirChartSummaryCardComponent', () => {
   let component: FhirChartSummaryCardComponent;
   let fixture: ComponentFixture<FhirChartSummaryCardComponent>;
+  let configService: MockConfigService;
+  let colorService: jasmine.SpyObj<DataLayerColorService>;
+  let summaryService: jasmine.SpyObj<SummaryService>;
 
   beforeEach(async () => {
+    configService = new MockConfigService();
+    summaryService = jasmine.createSpyObj('SummaryService', ['canSummarize', 'summarize']);
+    summaryService.canSummarize.and.returnValue(true);
+    summaryService.summarize.and.returnValue([{ name: 'summary' }]);
+    colorService = jasmine.createSpyObj('ColorService', ['getColorGradient']);
     await TestBed.configureTestingModule({
-      declarations: [FhirChartSummaryCardComponent],
-      imports: [MatCardModule, MatIconModule],
+      declarations: [FhirChartSummaryCardComponent, MockDynamicTableComponent],
+      imports: [MatTooltipModule, OverlayModule],
       providers: [
-        { provide: DataLayerColorService, useValue: mockColorService },
+        { provide: FhirChartConfigurationService, useValue: configService },
+        { provide: SummaryService, useValue: summaryService, multi: true },
+        { provide: DataLayerColorService, useValue: colorService },
         { provide: COLOR_PALETTE, useValue: ['#000000', '#ffffff'] },
       ],
     }).compileComponents();
@@ -30,5 +56,13 @@ describe('FhirChartSummaryCardComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should set inputs on dynamic-table component', () => {
+    const layer: ManagedDataLayer = { id: '1', name: 'layer', datasets: [{ label: 'dataset', data: [] }], scale: { id: 'test' } };
+    component.layer = layer;
+    fixture.detectChanges();
+    const statistics: DebugElement = fixture.debugElement.query(By.directive(MockDynamicTableComponent));
+    expect(statistics.componentInstance.data).toEqual([{ name: 'summary' }]);
   });
 });

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary-card/fhir-chart-summary-card.component.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary-card/fhir-chart-summary-card.component.ts
@@ -1,18 +1,78 @@
-import { Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Inject, Input, Output } from '@angular/core';
+import { FhirChartConfigurationService } from '../../fhir-chart/fhir-chart-configuration.service';
+import { DataLayer } from '../../data-layer/data-layer';
+import { DataLayerColorService } from '../../data-layer/data-layer-color.service';
+import { ConnectionPositionPair } from '@angular/cdk/overlay';
+import { SummaryService } from '../summary.service';
+import { NumberRange } from '../../utils';
 
 @Component({
   selector: 'fhir-chart-summary-card',
   templateUrl: './fhir-chart-summary-card.component.html',
   styleUrls: ['./fhir-chart-summary-card.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FhirChartSummaryCardComponent {
-  @Input() color?: string;
-  @Input() title?: string;
-  @Input() subtitle?: string;
-  @Input() icon?: string;
+  @Input() layer!: DataLayer;
+  _expanded = false;
+  get expanded() {
+    return this._expanded;
+  }
+  @Input() set expanded(value: boolean) {
+    this._expanded = value;
+    if (this._expanded) {
+      this.expand.next();
+    } else {
+      this.collapse.next();
+    }
+  }
+  @Output() expand = new EventEmitter<void>();
+  @Output() collapse = new EventEmitter<void>();
+
+  constructor(
+    public configService: FhirChartConfigurationService,
+    private colorService: DataLayerColorService,
+    private elementRef: ElementRef,
+    @Inject(SummaryService) private summaryServices: SummaryService[]
+  ) {}
+
+  overlayPositions: ConnectionPositionPair[] = [{ originX: 'start', originY: 'top', overlayX: 'start', overlayY: 'top' }];
+
+  get collapsedWidth(): number {
+    return this.elementRef.nativeElement.offsetWidth;
+  }
+  get collapsedHeight(): number {
+    return this.elementRef.nativeElement.offsetHeight;
+  }
+  get contentOverflow() {
+    return this.elementRef.nativeElement.scrollHeight > this.elementRef.nativeElement.offsetHeight;
+  }
+
+  getTooltip() {
+    if (this.contentOverflow) {
+      return 'Click to expand this card';
+    } else {
+      return '';
+    }
+  }
 
   getBackgroundStyle() {
-    // Use multiple background layers to apply a gradient to the border while keeping the rest of the card white
-    return `linear-gradient(white, white) padding-box, ${this.color} border-box`;
+    if (this.layer) {
+      const gradient = this.colorService.getColorGradient(this.layer);
+      // Use multiple background layers to apply a gradient to the border while keeping the rest of the card white
+      return `linear-gradient(white, white) padding-box, ${gradient} border-box`;
+    }
+    return undefined;
+  }
+
+  summarize(range: NumberRange | null) {
+    if (range) {
+      for (let summaryService of this.summaryServices) {
+        if (summaryService.canSummarize(this.layer)) {
+          return summaryService.summarize(this.layer, range);
+        }
+      }
+    }
+    return [{}];
   }
 }

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary-card/fhir-chart-summary-card.component.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary-card/fhir-chart-summary-card.component.ts
@@ -36,7 +36,7 @@ export class FhirChartSummaryCardComponent {
     @Inject(SummaryService) private summaryServices: SummaryService[]
   ) {}
 
-  overlayPositions: ConnectionPositionPair[] = [{ originX: 'start', originY: 'top', overlayX: 'start', overlayY: 'top' }];
+  overlayPositions: ConnectionPositionPair[] = [{ originX: 'start', originY: 'top', overlayX: 'start', overlayY: 'top', offsetX: -8 }];
 
   get collapsedWidth(): number {
     return this.elementRef.nativeElement.offsetWidth;

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary.module.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary.module.ts
@@ -7,10 +7,11 @@ import { DynamicTableModule } from '../dynamic-table/dynamic-table.module';
 import { FhirChartSummaryCardComponent } from './fhir-chart-summary-card/fhir-chart-summary-card.component';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatButtonModule } from '@angular/material/button';
+import { OverlayModule } from '@angular/cdk/overlay';
 
 @NgModule({
   declarations: [FhirChartSummaryComponent, FhirChartSummaryCardComponent],
-  imports: [CommonModule, MatCardModule, MatButtonModule, MatIconModule, MatTooltipModule, DynamicTableModule],
+  imports: [CommonModule, MatCardModule, MatButtonModule, MatIconModule, MatTooltipModule, DynamicTableModule, OverlayModule],
   exports: [FhirChartSummaryComponent],
 })
 export class FhirChartSummaryModule {}

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary.module.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary.module.ts
@@ -1,17 +1,14 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MatCardModule } from '@angular/material/card';
-import { MatIconModule } from '@angular/material/icon';
 import { FhirChartSummaryComponent } from './fhir-chart-summary/fhir-chart-summary.component';
 import { DynamicTableModule } from '../dynamic-table/dynamic-table.module';
 import { FhirChartSummaryCardComponent } from './fhir-chart-summary-card/fhir-chart-summary-card.component';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { MatButtonModule } from '@angular/material/button';
 import { OverlayModule } from '@angular/cdk/overlay';
 
 @NgModule({
   declarations: [FhirChartSummaryComponent, FhirChartSummaryCardComponent],
-  imports: [CommonModule, MatCardModule, MatButtonModule, MatIconModule, MatTooltipModule, DynamicTableModule, OverlayModule],
+  imports: [CommonModule, MatTooltipModule, DynamicTableModule, OverlayModule],
   exports: [FhirChartSummaryComponent],
 })
 export class FhirChartSummaryModule {}

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary.module.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary.module.ts
@@ -6,10 +6,11 @@ import { FhirChartSummaryComponent } from './fhir-chart-summary/fhir-chart-summa
 import { DynamicTableModule } from '../dynamic-table/dynamic-table.module';
 import { FhirChartSummaryCardComponent } from './fhir-chart-summary-card/fhir-chart-summary-card.component';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatButtonModule } from '@angular/material/button';
 
 @NgModule({
   declarations: [FhirChartSummaryComponent, FhirChartSummaryCardComponent],
-  imports: [CommonModule, MatCardModule, MatIconModule, MatTooltipModule, DynamicTableModule],
+  imports: [CommonModule, MatCardModule, MatButtonModule, MatIconModule, MatTooltipModule, DynamicTableModule],
   exports: [FhirChartSummaryComponent],
 })
 export class FhirChartSummaryModule {}

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.css
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.css
@@ -2,9 +2,13 @@
   height: 100%;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 5px;
 }
 .dataset-summary {
-  flex: 1 1 auto;
+  flex: 0 0 auto;
   overflow-y: auto;
+}
+.card-button {
+  position: absolute;
+  margin-left: -48px;
 }

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.css
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.css
@@ -1,14 +1,19 @@
 .chart-summary {
   height: 100%;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  /* grid-template-rows is set dynamically */
+  grid-template-columns: 1fr;
   gap: 5px;
 }
 .dataset-summary {
-  flex: 0 0 auto;
-  overflow-y: auto;
+  pointer-events: all;
+  /* grid-row is set dynamically */
+  grid-column: 1;
+  overflow-y: hidden;
 }
-.card-button {
-  position: absolute;
-  margin-left: -48px;
+.backdrop {
+  grid-row: 1 / -1;
+  grid-column: 1;
+  background-color: rgba(0, 0, 0, 0.05);
+  z-index: 100;
 }

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.html
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.html
@@ -1,26 +1,17 @@
-<ng-container *ngIf="configService.timelineRange$ | async as range">
-  <ng-container *ngIf="scalePositions$ | async as positions">
-    <ng-container *ngIf="layerManager.enabledLayers$ | async as layers">
-      <div class="chart-summary" [style.paddingTop]="positions[layers[0].scale.id].top + 'px'">
-        <fhir-chart-summary-card
-          *ngFor="let layer of layerManager.enabledLayers$ | async; let index = index"
-          [color]="colorService.getColorGradient(layer)"
-          [title]="layer.name"
-          icon="info"
-          class="dataset-summary mat-elevation-z2"
-          [style.top]="positions[layer.scale.id].top + 'px'"
-          [style.height]="positions[layer.scale.id].height - 5 + 'px'"
-          #card
-        >
-          <button mat-icon-button color="primary" class="card-button" *ngIf="!layer.focused" matTooltip="Expand this chart" (click)="onCardClick(layer, index)">
-            <mat-icon>unfold_more</mat-icon>
-          </button>
-          <button mat-icon-button color="primary" class="card-button" *ngIf="layer.focused" matTooltip="Shrink this chart" (click)="onCardClick(layer, index)">
-            <mat-icon>unfold_less</mat-icon>
-          </button>
-          <dynamic-table [data]="summarize(layer, range)" #table></dynamic-table>
-        </fhir-chart-summary-card>
-      </div>
-    </ng-container>
+<ng-container *ngIf="scalePositions$ | async as positions">
+  <ng-container *ngIf="layerManager.enabledLayers$ | async as layers">
+    <div class="chart-summary" [style.paddingTop]="positions[layers[0].scale.id].top + 'px'" [style.gridTemplateRows]="gridTemplateRows$ | async">
+      <fhir-chart-summary-card
+        *ngFor="let layer of layerManager.enabledLayers$ | async; let index = index"
+        class="dataset-summary mat-elevation-z2"
+        [style.gridRow]="index + 1"
+        [layer]="layer"
+        [expanded]="expandedCard === layer.id"
+        (expand)="onCardExpand(layer.id)"
+        (collapse)="onCardCollapse(layer.id)"
+      >
+      </fhir-chart-summary-card>
+      <div class="backdrop" *ngIf="expandedCard != null" (click)="expandedCard = null"></div>
+    </div>
   </ng-container>
 </ng-container>

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.html
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.html
@@ -1,13 +1,26 @@
-<div class="chart-summary">
-  <ng-container *ngIf="configService.timelineRange$ | async as range">
-    <fhir-chart-summary-card
-      *ngFor="let layer of layerManager.enabledLayers$ | async"
-      [color]="colorService.getColorGradient(layer)"
-      [title]="layer.name"
-      icon="info"
-      class="dataset-summary mat-elevation-z2"
-    >
-      <dynamic-table [data]="summarize(layer, range)"> </dynamic-table>
-    </fhir-chart-summary-card>
+<ng-container *ngIf="configService.timelineRange$ | async as range">
+  <ng-container *ngIf="scalePositions$ | async as positions">
+    <ng-container *ngIf="layerManager.enabledLayers$ | async as layers">
+      <div class="chart-summary" [style.paddingTop]="positions[layers[0].scale.id].top + 'px'">
+        <fhir-chart-summary-card
+          *ngFor="let layer of layerManager.enabledLayers$ | async; let index = index"
+          [color]="colorService.getColorGradient(layer)"
+          [title]="layer.name"
+          icon="info"
+          class="dataset-summary mat-elevation-z2"
+          [style.top]="positions[layer.scale.id].top + 'px'"
+          [style.height]="positions[layer.scale.id].height - 5 + 'px'"
+          #card
+        >
+          <button mat-icon-button color="primary" class="card-button" *ngIf="!layer.focused" matTooltip="Expand this chart" (click)="onCardClick(layer, index)">
+            <mat-icon>unfold_more</mat-icon>
+          </button>
+          <button mat-icon-button color="primary" class="card-button" *ngIf="layer.focused" matTooltip="Shrink this chart" (click)="onCardClick(layer, index)">
+            <mat-icon>unfold_less</mat-icon>
+          </button>
+          <dynamic-table [data]="summarize(layer, range)" #table></dynamic-table>
+        </fhir-chart-summary-card>
+      </div>
+    </ng-container>
   </ng-container>
-</div>
+</ng-container>

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.html
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.html
@@ -1,7 +1,11 @@
 <ng-container *ngIf="scalePositions$ | async as positions">
   <ng-container *ngIf="layerManager.enabledLayers$ | async as layers">
     <ng-container *ngIf="layers.length > 0">
-      <div class="chart-summary" [style.paddingTop]="positions[layers[0].scale.id].top + 'px'" [style.gridTemplateRows]="gridTemplateRows$ | async">
+      <div
+        class="chart-summary"
+        [style.paddingTop]="autoAlign ? positions[layers[0].scale.id].top + 'px' : '0'"
+        [style.gridTemplateRows]="autoAlign ? (gridTemplateRows$ | async) : ''"
+      >
         <fhir-chart-summary-card
           *ngFor="let layer of layers; let index = index"
           class="dataset-summary mat-elevation-z2"

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.html
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.html
@@ -1,17 +1,19 @@
 <ng-container *ngIf="scalePositions$ | async as positions">
   <ng-container *ngIf="layerManager.enabledLayers$ | async as layers">
-    <div class="chart-summary" [style.paddingTop]="positions[layers[0].scale.id].top + 'px'" [style.gridTemplateRows]="gridTemplateRows$ | async">
-      <fhir-chart-summary-card
-        *ngFor="let layer of layerManager.enabledLayers$ | async; let index = index"
-        class="dataset-summary mat-elevation-z2"
-        [style.gridRow]="index + 1"
-        [layer]="layer"
-        [expanded]="expandedCard === layer.id"
-        (expand)="onCardExpand(layer.id)"
-        (collapse)="onCardCollapse(layer.id)"
-      >
-      </fhir-chart-summary-card>
-      <div class="backdrop" *ngIf="expandedCard != null" (click)="expandedCard = null"></div>
-    </div>
+    <ng-container *ngIf="layers.length > 0">
+      <div class="chart-summary" [style.paddingTop]="positions[layers[0].scale.id].top + 'px'" [style.gridTemplateRows]="gridTemplateRows$ | async">
+        <fhir-chart-summary-card
+          *ngFor="let layer of layerManager.enabledLayers$ | async; let index = index"
+          class="dataset-summary mat-elevation-z2"
+          [style.gridRow]="index + 1"
+          [layer]="layer"
+          [expanded]="expandedCard === layer.id"
+          (expand)="onCardExpand(layer.id)"
+          (collapse)="onCardCollapse(layer.id)"
+        >
+        </fhir-chart-summary-card>
+        <div class="backdrop" *ngIf="expandedCard != null" (click)="expandedCard = null"></div>
+      </div>
+    </ng-container>
   </ng-container>
 </ng-container>

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.html
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.html
@@ -3,7 +3,7 @@
     <ng-container *ngIf="layers.length > 0">
       <div class="chart-summary" [style.paddingTop]="positions[layers[0].scale.id].top + 'px'" [style.gridTemplateRows]="gridTemplateRows$ | async">
         <fhir-chart-summary-card
-          *ngFor="let layer of layerManager.enabledLayers$ | async; let index = index"
+          *ngFor="let layer of layers; let index = index"
           class="dataset-summary mat-elevation-z2"
           [style.gridRow]="index + 1"
           [layer]="layer"

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.spec.ts
@@ -23,7 +23,7 @@ class MockFhirChartSummaryCardComponent {
   @Input() expanded: unknown;
 }
 
-fdescribe('FhirChartSummaryComponent', () => {
+describe('FhirChartSummaryComponent', () => {
   let component: FhirChartSummaryComponent;
   let fixture: ComponentFixture<FhirChartSummaryComponent>;
   let layerManager: MockLayerManager;
@@ -69,6 +69,29 @@ fdescribe('FhirChartSummaryComponent', () => {
     const cards = fixture.debugElement.queryAll(By.directive(MockFhirChartSummaryCardComponent));
     expect(cards.length).toBe(3);
   });
+
+  it('should create a grid layout from scale positions', () => {
+    layerManager.enabledLayers$.next([
+      { id: '1', name: 'layer 1', datasets: [], scale: { id: 'one' } },
+      { id: '2', name: 'layer 2', datasets: [], scale: { id: 'two' } },
+      { id: '3', name: 'layer 3', datasets: [], scale: { id: 'three' } },
+    ]);
+    lifecycleService.afterUpdate$.next([
+      {
+        scales: {
+          x: { axis: 'x', top: 50, bottom: 60, height: 10 },
+          three: { axis: 'y', top: 40, bottom: 70, height: 30 },
+          two: { axis: 'y', top: 20, bottom: 40, height: 20 },
+          one: { axis: 'y', top: 10, bottom: 20, height: 10 },
+        },
+      },
+    ]);
+    fixture.detectChanges();
+    const summary = fixture.debugElement.query(By.css('.chart-summary'));
+    expect(summary.styles['gridTemplateRows']).toBe('5px 15px 25px auto');
+  });
+
+  // card sizing doesn't match order in cardio 31059
 
   it('should set inputs on fhir-chart-summary-card component', () => {
     const layer: ManagedDataLayer = { id: '1', name: 'layer', datasets: [{ label: 'dataset', data: [] }], scale: { id: 'test' } };

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.spec.ts
@@ -72,7 +72,8 @@ describe('FhirChartSummaryComponent', () => {
     expect(cards.length).toBe(3);
   });
 
-  it('should create a grid layout from scale positions', () => {
+  it('should create a grid layout from scale positions when autoAlign=true', () => {
+    fixture.componentRef.setInput('autoAlign', true);
     layerManager.enabledLayers$.next([
       { id: '1', name: 'layer 1', datasets: [], scale: { id: 'one' } },
       { id: '2', name: 'layer 2', datasets: [], scale: { id: 'two' } },
@@ -91,6 +92,22 @@ describe('FhirChartSummaryComponent', () => {
     fixture.detectChanges();
     const summary = fixture.debugElement.query(By.css('.chart-summary'));
     expect(summary.styles['gridTemplateRows']).toBe('5px 15px 25px auto');
+  });
+
+  it('should use implicit grid rows when autoAlign=false', () => {
+    fixture.componentRef.setInput('autoAlign', false);
+    layerManager.enabledLayers$.next([{ id: '1', name: 'layer 1', datasets: [], scale: { id: 'one' } }]);
+    lifecycleService.afterUpdate$.next([
+      {
+        scales: {
+          x: { axis: 'x', top: 50, bottom: 60, height: 10 },
+          one: { axis: 'y', top: 10, bottom: 20, height: 10 },
+        },
+      },
+    ]);
+    fixture.detectChanges();
+    const summary = fixture.debugElement.query(By.css('.chart-summary'));
+    expect(summary.styles['gridTemplateRows']).toBe('');
   });
 
   it('should set inputs on fhir-chart-summary-card component', () => {

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.ts
@@ -1,10 +1,14 @@
-import { Component, Inject } from '@angular/core';
-import { DataLayer } from '../../data-layer/data-layer';
+import { Component, ElementRef, Inject, QueryList, ViewChildren } from '@angular/core';
+import { DataLayer, ManagedDataLayer } from '../../data-layer/data-layer';
 import { DataLayerColorService } from '../../data-layer/data-layer-color.service';
 import { DataLayerManagerService } from '../../data-layer/data-layer-manager.service';
 import { FhirChartConfigurationService } from '../../fhir-chart/fhir-chart-configuration.service';
 import { NumberRange } from '../../utils';
 import { SummaryService } from '../summary.service';
+import { combineLatest, map } from 'rxjs';
+import { FhirChartLifecycleService } from '../../fhir-chart/fhir-chart-lifecycle.service';
+import { mapValues } from 'lodash-es';
+import { FhirChartSummaryCardComponent } from '../fhir-chart-summary-card/fhir-chart-summary-card.component';
 
 /**
  * See `*ChartSummary` for example usage.
@@ -19,8 +23,17 @@ export class FhirChartSummaryComponent {
     public layerManager: DataLayerManagerService,
     public configService: FhirChartConfigurationService,
     public colorService: DataLayerColorService,
-    @Inject(SummaryService) private summaryServices: SummaryService[]
+    @Inject(SummaryService) private summaryServices: SummaryService[],
+    private lifecycleService: FhirChartLifecycleService
   ) {}
+
+  @ViewChildren('card', { read: ElementRef }) cards!: QueryList<ElementRef>;
+
+  scalePositions$ = this.lifecycleService.afterUpdate$.pipe(map(([chart]) => mapValues(chart.scales, ({ top, bottom, height }) => ({ top, bottom, height }))));
+
+  onCardClick(layer: ManagedDataLayer, index: number) {
+    this.layerManager.focus(layer.id, this.cards.get(index)?.nativeElement.scrollHeight);
+  }
 
   summarize(layer: DataLayer, range: NumberRange | null) {
     if (range) {

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { DataLayerManagerService } from '../../data-layer/data-layer-manager.service';
-import { map, tap } from 'rxjs';
+import { map } from 'rxjs';
 import { FhirChartLifecycleService } from '../../fhir-chart/fhir-chart-lifecycle.service';
 import { mapValues } from 'lodash-es';
 

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { DataLayerManagerService } from '../../data-layer/data-layer-manager.service';
 import { combineLatest, map, shareReplay } from 'rxjs';
 import { FhirChartLifecycleService } from '../../fhir-chart/fhir-chart-lifecycle.service';
@@ -15,6 +15,9 @@ import { mapValues } from 'lodash-es';
 })
 export class FhirChartSummaryComponent {
   constructor(public layerManager: DataLayerManagerService, private lifecycleService: FhirChartLifecycleService) {}
+
+  /** When set to `true`, each card will be vertically aligned with the corresponding chart. */
+  @Input() autoAlign = false;
 
   scalePositions$ = this.lifecycleService.afterUpdate$.pipe(
     map(([chart]) => mapValues(chart.scales, ({ axis, top, bottom, height }) => ({ axis, top, bottom, height }))),

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/statistics.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/statistics.service.ts
@@ -64,10 +64,10 @@ export class StatisticsService {
   /** Format a set of statistics as strings */
   private formatStatistics({ days, reported, outOfRange, average, median }: CombinedStats, precision: number) {
     return {
-      'Days Reported': formatFraction(reported.length, days),
-      ...(outOfRange == null ? {} : { 'Outside Goal': formatFraction(outOfRange.length, reported.length) }),
       Average: formatMultipleValues(average, precision),
       Median: formatMultipleValues(median, precision),
+      ...(outOfRange == null ? {} : { 'Outside Goal': formatFraction(outOfRange.length, reported.length) }),
+      'Days Reported': formatFraction(reported.length, days),
     };
   }
 

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-lifecycle.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-lifecycle.service.spec.ts
@@ -1,0 +1,53 @@
+import { Chart } from 'chart.js';
+import { FhirChartLifecycleService } from './fhir-chart-lifecycle.service';
+import { firstValueFrom } from 'rxjs';
+import { TestBed } from '@angular/core/testing';
+
+describe('FhirChartLifecycleService', () => {
+  let wrapper: HTMLDivElement;
+  let canvas: HTMLCanvasElement;
+  let service: FhirChartLifecycleService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(FhirChartLifecycleService);
+    // These tests create a real chart so they can make sure the service's plugin is
+    // properly registered with Chart.js and listening to the correct callbacks.
+    wrapper = document.createElement('div');
+    canvas = document.createElement('canvas', {});
+    canvas.width = 100;
+    canvas.height = 100;
+    wrapper.appendChild(canvas);
+    document.body.appendChild(wrapper);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(wrapper);
+  });
+
+  it('afterInit$ should emit after a chart is initialized', async () => {
+    // using setTimeout so the chart will be created after we've subscribed to the observable
+    let chart: Chart;
+    setTimeout(() => {
+      chart = new Chart(canvas, {
+        data: {
+          datasets: [],
+        },
+      });
+    });
+    const args = await firstValueFrom(service.afterInit$);
+    expect(args[0]).toBe(chart!);
+  });
+
+  it('afterUpdate$ should emit after a chart is updated', async () => {
+    const chart = new Chart(canvas, {
+      data: {
+        datasets: [],
+      },
+    });
+    // using setTimeout so the chart update will happen after we've subscribed to the observable
+    setTimeout(() => chart.update());
+    const args = await firstValueFrom(service.afterUpdate$);
+    expect(args[0]).toBe(chart);
+  });
+});

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-lifecycle.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-lifecycle.service.ts
@@ -8,12 +8,12 @@ import { Subject } from 'rxjs';
 })
 export class FhirChartLifecycleService {
   constructor() {
-    console.log('Registering reactive-chart-plugin');
+    console.log('Registering lifecycle-service-plugin');
     Chart.register(this.plugin);
   }
 
   private plugin: Plugin = {
-    id: 'reactive-chart-plugin',
+    id: 'lifecycle-service-plugin',
     afterInit: (...args) => this.afterInit.next(args),
     afterUpdate: (...args) => this.afterUpdate.next(args),
   };

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-lifecycle.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-lifecycle.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { Chart, Plugin } from 'chart.js';
+import { Subject } from 'rxjs';
+
+/** Registers a chartjs plugin and exposes chart lifecycle events as Observables */
+@Injectable({
+  providedIn: 'root',
+})
+export class FhirChartLifecycleService {
+  constructor() {
+    console.log('Registering reactive-chart-plugin');
+    Chart.register(this.plugin);
+  }
+
+  private plugin: Plugin = {
+    id: 'reactive-chart-plugin',
+    afterInit: (...args) => this.afterInit.next(args),
+    afterUpdate: (...args) => this.afterUpdate.next(args),
+  };
+
+  private afterInit = new Subject<Parameters<NonNullable<Plugin['afterInit']>>>();
+  afterInit$ = this.afterInit.asObservable();
+
+  private afterUpdate = new Subject<Parameters<NonNullable<Plugin['afterUpdate']>>>();
+  afterUpdate$ = this.afterUpdate.asObservable();
+}

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-lifecycle.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-lifecycle.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, OnDestroy } from '@angular/core';
 import { Chart, Plugin } from 'chart.js';
 import { Subject } from 'rxjs';
 
@@ -6,10 +6,17 @@ import { Subject } from 'rxjs';
 @Injectable({
   providedIn: 'root',
 })
-export class FhirChartLifecycleService {
+export class FhirChartLifecycleService implements OnDestroy {
   constructor() {
-    console.log('Registering lifecycle-service-plugin');
-    Chart.register(this.plugin);
+    if (Chart.registry.plugins.get(this.plugin.id)) {
+      console.warn('lifecycle-service-plugin has already been registered');
+    } else {
+      Chart.register(this.plugin);
+    }
+  }
+
+  ngOnDestroy(): void {
+    Chart.unregister(this.plugin);
   }
 
   private plugin: Plugin = {


### PR DESCRIPTION
## Overview

- added `autoAlign` input to `fhir-chart-summary` component, which will align each summary card with the corresponding chart.
- Summary cards can be expanded to full size by clicking on them.
- `dynamic-table` component now uses a basic CSS grid instead of MatTable. Row height scales proportionally so more content can fit into a smaller area.
- Re-ordered the rows returned by `StatisticsService` so the most important things are at the top.
- Added `FhirChartLifecycleService` that registers a chart.js plugin and exposes Observables for chart lifecycle events

## How it was tested

- Ran all apps and tested summary cards at different window sizes
- Tested app functionality with card expanded
- Tested both horizontal and vertical layout in patient app

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [x] I have included screen shots for changes that affect the user interface
- [x] I have updated unit tests
- [x] I have run unit tests locally
- [x] I have updated documentation (including README)
