### PR TITLE
Split y-axis labels into two lines

### DIFF
--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/medication-request/simple-medication-mapper.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/medication-request/simple-medication-mapper.service.spec.ts
@@ -70,7 +70,7 @@ describe('SimpleMedicationMapper', () => {
       expect(mapper.map(medication).scale).toEqual({
         id: 'medications',
         type: 'category',
-        title: { text: 'Medication Prescriptions' },
+        title: { text: ['Prescribed', 'Medications'] },
       });
     });
   });

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/medication-request/simple-medication-mapper.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/medication-request/simple-medication-mapper.service.ts
@@ -33,7 +33,7 @@ export class SimpleMedicationMapper implements Mapper<SimpleMedication> {
   map(resource: SimpleMedication): DataLayer<TimelineChartType, MedicationDataPoint[]> {
     const authoredOn = new Date(resource.authoredOn).getTime();
     return {
-      name: 'Medication Prescriptions',
+      name: 'Prescribed Medications',
       category: ['medication'],
       datasets: [
         {
@@ -59,7 +59,7 @@ export class SimpleMedicationMapper implements Mapper<SimpleMedication> {
       ],
       scale: merge({}, this.medicationScaleOptions, {
         id: 'medications',
-        title: { text: 'Medication Prescriptions' },
+        title: { text: ['Prescribed', 'Medications'] },
       }),
       // use annotations for labels so they are drawn on top of the data (axis labels are drawn underneath)
       annotations: [

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/component-observation-mapper.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/component-observation-mapper.service.spec.ts
@@ -108,9 +108,9 @@ describe('ComponentObservationMapper', () => {
       const mapper = new ComponentObservationMapper({ type: 'linear' }, {});
       expect(mapper.map(observation).scale).toEqual(
         jasmine.objectContaining({
-          id: 'text (unit)',
+          id: 'text',
           type: 'linear',
-          title: { text: 'text (unit)' },
+          title: { text: ['text', 'unit'] },
         })
       );
     });
@@ -138,7 +138,7 @@ describe('ComponentObservationMapper', () => {
       expect(mapper.map(observation).annotations?.[0]).toEqual(
         jasmine.objectContaining({
           type: 'box',
-          yScaleID: 'text (unit)',
+          yScaleID: 'text',
           yMin: 1,
           yMax: 10,
         })

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/component-observation-mapper.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/component-observation-mapper.service.ts
@@ -51,7 +51,7 @@ export class ComponentObservationMapper implements Mapper<ComponentObservation> 
   ) {}
   canMap = isComponentObservation;
   map(resource: ComponentObservation): DataLayer {
-    const scaleName = `${resource.code.text} (${resource.component[0].valueQuantity.unit})`;
+    const scaleName = resource.code.text;
     return {
       name: resource.code.text,
       category: resource.category?.flatMap((c) => c.coding?.map((coding) => coding.display)).filter(isDefined),
@@ -74,7 +74,7 @@ export class ComponentObservationMapper implements Mapper<ComponentObservation> 
         })),
       scale: merge({}, this.linearScaleOptions, {
         id: scaleName,
-        title: { text: scaleName },
+        title: { text: [scaleName, resource.component[0].valueQuantity.unit] },
         stackWeight: resource.component.length,
       }),
       annotations: resource.component.flatMap(

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/simple-observation-mapper.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/simple-observation-mapper.service.spec.ts
@@ -64,9 +64,9 @@ describe('SimpleObservationMapper', () => {
       };
       const mapper = new SimpleObservationMapper({ type: 'linear' }, {});
       expect(mapper.map(observation).scale).toEqual({
-        id: 'text (unit)',
+        id: 'text',
         type: 'linear',
-        title: { text: 'text (unit)' },
+        title: { text: ['text', 'unit'] },
       });
     });
 
@@ -88,7 +88,7 @@ describe('SimpleObservationMapper', () => {
       expect(mapper.map(observation).annotations?.[0]).toEqual(
         jasmine.objectContaining({
           type: 'box',
-          yScaleID: 'text (unit)',
+          yScaleID: 'text',
           yMin: 1,
           yMax: 10,
         })

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/simple-observation-mapper.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/simple-observation-mapper.service.ts
@@ -40,7 +40,7 @@ export class SimpleObservationMapper implements Mapper<SimpleObservation> {
   ) {}
   canMap = isSimpleObservation;
   map(resource: SimpleObservation): DataLayer {
-    const scaleName = `${resource.code.text} (${resource.valueQuantity.unit})`;
+    const scaleName = resource.code.text;
     return {
       name: resource.code.text,
       category: resource.category?.flatMap((c) => c.coding?.map((coding) => coding.display)).filter(isDefined),
@@ -63,7 +63,7 @@ export class SimpleObservationMapper implements Mapper<SimpleObservation> {
       ],
       scale: merge({}, this.linearScaleOptions, {
         id: scaleName,
-        title: { text: scaleName },
+        title: { text: [scaleName, resource.valueQuantity.unit] },
       }),
       annotations: resource.referenceRange?.map<ChartAnnotation>((range) =>
         merge({}, this.annotationOptions, {


### PR DESCRIPTION
## Overview

- split y-axis labels into two lines to improve readability on small screens

## How it was tested

- Ran cardio app, resized browser window and checked y-axis labels.

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [x] I have included screen shots for changes that affect the user interface
- [x] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
