### PR TITLE
RT-733-ignore-scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM node:18.13.0-alpine AS build
 USER node
 WORKDIR /home/node
 COPY --chown=node package*.json ./
-RUN npm ci
+RUN npm ci --ignore-scripts
+RUN npm rebuild @parcel/watcher nice-napi nx esbuild @swc/core
 COPY --chown=node . .
 ARG app
 RUN npm run build ${app}


### PR DESCRIPTION
## Overview
- Update `RUN npm ci` to `RUN npm ci --ignore-script` in Dockerfile.
- Rebuild and keep package scripts manually. (RUN npm rebuild @parcel/watcher nice-napi nx esbuild @swc/core).


## How it was tested
Tested using run `Dockerfile` locally.


## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)
