### PR TITLE
Medication Tooltip Positioner

### DIFF
--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart/center-tooltip-positioner.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart/center-tooltip-positioner.spec.ts
@@ -1,0 +1,91 @@
+import { BarElement, ChartType, Tooltip, TooltipModel } from 'chart.js';
+import { ActiveElement } from 'chart.js/dist/plugins/plugin.tooltip';
+import './center-tooltip-positioner';
+
+describe('Tooltip.positioners.center', () => {
+  it('should return center point of floating bar', () => {
+    const elements: ActiveElement[] = [
+      {
+        element: new BarElement({ x: 100, y: 50, width: 50, height: 10 }),
+        datasetIndex: 0,
+        index: 0,
+      },
+    ];
+    const tooltipModel = {
+      chart: {
+        chartArea: { width: 500, height: 500 },
+      },
+    } as TooltipModel<ChartType>;
+    const position = Tooltip.positioners.center.apply(tooltipModel, [elements, { x: 50, y: 50 }]);
+    expect(position).toEqual(
+      jasmine.objectContaining({
+        x: 75,
+        y: 50,
+      })
+    );
+  });
+
+  it('should return coordinates of point element', () => {
+    const elements: ActiveElement[] = [
+      {
+        element: new BarElement({ x: 100, y: 50 }),
+        datasetIndex: 0,
+        index: 0,
+      },
+    ];
+    const tooltipModel = {
+      chart: {
+        chartArea: { width: 500, height: 500 },
+      },
+    } as TooltipModel<ChartType>;
+    const position = Tooltip.positioners.center.apply(tooltipModel, [elements, { x: 100, y: 50 }]);
+    expect(position).toEqual(
+      jasmine.objectContaining({
+        x: 100,
+        y: 50,
+      })
+    );
+  });
+
+  it('should return yAlign top if bar is in the top half of the chart', () => {
+    const elements: ActiveElement[] = [
+      {
+        element: new BarElement({ x: 100, y: 50, width: 50, height: 10 }),
+        datasetIndex: 0,
+        index: 0,
+      },
+    ];
+    const tooltipModel = {
+      chart: {
+        chartArea: { width: 500, height: 500 },
+      },
+    } as TooltipModel<ChartType>;
+    const position = Tooltip.positioners.center.apply(tooltipModel, [elements, { x: 50, y: 50 }]);
+    expect(position).toEqual(
+      jasmine.objectContaining({
+        yAlign: 'top',
+      })
+    );
+  });
+
+  it('should return yAlign bottom if bar is in the bottom half of the chart', () => {
+    const elements: ActiveElement[] = [
+      {
+        element: new BarElement({ x: 100, y: 450, width: 50, height: 10 }),
+        datasetIndex: 0,
+        index: 0,
+      },
+    ];
+    const tooltipModel = {
+      chart: {
+        chartArea: { width: 500, height: 500 },
+      },
+    } as TooltipModel<ChartType>;
+    const position = Tooltip.positioners.center.apply(tooltipModel, [elements, { x: 50, y: 450 }]);
+    expect(position).toEqual(
+      jasmine.objectContaining({
+        yAlign: 'bottom',
+      })
+    );
+  });
+});

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart/center-tooltip-positioner.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart/center-tooltip-positioner.ts
@@ -1,0 +1,33 @@
+import { ChartType, Tooltip, TooltipPositionerFunction } from 'chart.js';
+
+declare module 'chart.js' {
+  interface TooltipPositionerMap {
+    center: TooltipPositionerFunction<ChartType>;
+  }
+}
+
+/**
+ * Custom positioner that centers tooltip anchor point for floating bars.
+ * Only supports horizontal bar charts.
+ */
+Tooltip.positioners.center = function (elements) {
+  if (elements.length) {
+    const props = elements[0].element.getProps(['width']);
+    const width = Number(props['width'] ?? 0);
+    const yAlign = elements[0].element.y > this.chart.chartArea.height / 2 ? 'bottom' : 'top';
+    if (width) {
+      // BarElement: (x,y) coordinate is at the end of the bar, vertically centered (for horizontal bar)
+      return {
+        x: elements[0].element.x - width / 2,
+        y: elements[0].element.y,
+        yAlign,
+      };
+    }
+    // Point
+    return {
+      x: elements[0].element.x,
+      y: elements[0].element.y,
+    };
+  }
+  return { x: 0, y: 0 };
+};

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.ts
@@ -8,6 +8,7 @@ import { DataLayerManagerService } from '../data-layer/data-layer-manager.servic
 import { findReferenceRangeForDataset } from '../fhir-chart-summary/statistics.service';
 import { TODAY_DATE_VERTICAL_LINE_ANNOTATION, TIME_SCALE_OPTIONS } from '../fhir-mappers/fhir-mapper-options';
 import { ChartAnnotation, ChartAnnotations, ChartScales, formatDateTime, isDefined, NumberRange } from '../utils';
+import './center-tooltip-positioner';
 
 export type TimelineConfiguration = ChartConfiguration<TimelineChartType, TimelineDataPoint[]>;
 
@@ -140,6 +141,7 @@ export class FhirChartConfigurationService {
             },
           },
           tooltip: {
+            position: 'center',
             callbacks: {
               title: (items) => items.map(getTooltipTitle),
               label: (item) => (item.raw as any)['tooltip'] ?? (Chart.defaults.plugins.tooltip.callbacks as any).label(item),


### PR DESCRIPTION
## Overview

- Adds a custom tooltip positioner for centering the tooltip on medication bar charts

## How it was tested

- Tested tooltip position with medication bars near the top, bottom, left, and right sides of the chart to make sure tooltip is always visible, caret is pointing at the correct anchor point, and tooltip does not cover the bar
- Regression tested tooltip for points

## Checklist

- [x] The title contains a short meaningful summary
- [ ] I have added a link to this PR in the Jira issue
- [ ] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)
