### PR TITLE
Fix test-npm-package failure

### DIFF
--- a/libs/ngx-charts-on-fhir/test-npm-package.sh
+++ b/libs/ngx-charts-on-fhir/test-npm-package.sh
@@ -24,7 +24,7 @@ echo ::::: Installing Charts-on-FHIR library
 npm i ../../dist/libs/ngx-charts-on-fhir/${PACKAGE_FILE}
 
 echo ::::: Building the Angular app
-npx ng build
+npx \@angular/cli@${MIN_ANGULAR_VERSION} build
 
 echo ::::: Cleaning up temporary files
 cd ..

--- a/libs/ngx-charts-on-fhir/test-npm-package.sh
+++ b/libs/ngx-charts-on-fhir/test-npm-package.sh
@@ -17,6 +17,7 @@ echo ::::: Creating a new Angular app
 mkdir -p tmp
 cd tmp
 rm -rf ./test-app
+npx \@angular/cli@${MIN_ANGULAR_VERSION} version
 npx --yes \@angular/cli@${MIN_ANGULAR_VERSION} new test-app --defaults
 cd test-app
 
@@ -24,7 +25,6 @@ echo ::::: Installing Charts-on-FHIR library
 npm i ../../dist/libs/ngx-charts-on-fhir/${PACKAGE_FILE}
 
 echo ::::: Building the Angular app
-npx \@angular/cli@${MIN_ANGULAR_VERSION} version
 npx \@angular/cli@${MIN_ANGULAR_VERSION} build
 
 echo ::::: Cleaning up temporary files

--- a/libs/ngx-charts-on-fhir/test-npm-package.sh
+++ b/libs/ngx-charts-on-fhir/test-npm-package.sh
@@ -24,6 +24,7 @@ echo ::::: Installing Charts-on-FHIR library
 npm i ../../dist/libs/ngx-charts-on-fhir/${PACKAGE_FILE}
 
 echo ::::: Building the Angular app
+npx \@angular/cli@${MIN_ANGULAR_VERSION} version
 npx \@angular/cli@${MIN_ANGULAR_VERSION} build
 
 echo ::::: Cleaning up temporary files


### PR DESCRIPTION
## Overview

- `test-npm-package` script was failing because it was using `ng build` command without a local angular cli installed in the project dir
- This change specifies the same angular cli version for `ng build` command that was used for `ng new`

## How it was tested

- ran the script locally and verified that it completes successfully

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)
