### PR TITLE
Customize layer names

### DIFF
--- a/apps/cardiovascular-health/src/app/app.component.ts
+++ b/apps/cardiovascular-health/src/app/app.component.ts
@@ -7,24 +7,15 @@ import { DataLayerManagerService } from '@elimuinformatics/ngx-charts-on-fhir';
   styleUrls: ['./app.component.scss'],
 })
 export class AppComponent implements OnInit {
-  layers = [
-    'Blood Pressure',
-    'Heart rate',
-    'Glucose',
-    'Hemoglobin A1c/Hemoglobin.total in Blood',
-    'O2 Sat',
-    'Step Count',
-    'Body Weight',
-    'Prescribed Medications',
-  ];
+  layers = ['Blood Pressure', 'Heart Rate', 'Glucose', 'Hemoglobin A1c', 'O2 Saturation', 'Step Count', 'Body Weight', 'Prescribed Medications'];
   views = {
     Cardiovascular: {
       selected: this.layers,
-      enabled: ['Blood Pressure', 'Heart rate', 'Step Count', 'Body Weight', 'Prescribed Medications'],
+      enabled: ['Blood Pressure', 'Heart Rate', 'Step Count', 'Body Weight', 'Prescribed Medications'],
     },
     Diabetes: {
       selected: this.layers,
-      enabled: ['Glucose', 'Hemoglobin A1c/Hemoglobin.total in Blood', 'Step Count', 'Body Weight', 'Prescribed Medications'],
+      enabled: ['Glucose', 'Hemoglobin A1c', 'Step Count', 'Body Weight', 'Prescribed Medications'],
     },
   };
 

--- a/apps/cardiovascular-health/src/app/datasets/observations.json
+++ b/apps/cardiovascular-health/src/app/datasets/observations.json
@@ -1,0 +1,57 @@
+[
+  {
+    "system": "http://loinc.org",
+    "code": "29463-7",
+    "display": "Body Weight"
+  },
+  {
+    "system": "http://loinc.org",
+    "code": "85354-9",
+    "display": "Blood Pressure"
+  },
+  {
+    "system": "http://loinc.org",
+    "code": "8480-6",
+    "display": "Systolic"
+  },
+  {
+    "system": "http://loinc.org",
+    "code": "8462-4",
+    "display": "Diastolic"
+  },
+  {
+    "system": "http://loinc.org",
+    "code": "8867-4",
+    "display": "Heart Rate"
+  },
+  {
+    "system": "http://loinc.org",
+    "code": "74774-1",
+    "display": "Glucose"
+  },
+  {
+    "system": "http://loinc.org",
+    "code": "2339-0",
+    "display": "Glucose"
+  },
+  {
+    "system": "http://loinc.org",
+    "code": "4548-4",
+    "display": "Hemoglobin A1c"
+  },
+  {
+    "system": "http://loinc.org",
+    "code": "59408-5",
+    "display": "O2 Saturation"
+  },
+  {
+    "system": "http://loinc.org",
+    "code": "55423-8",
+    "display": "Step Count"
+  },
+  {
+    "system": "http://loinc.org",
+    "code": "41950-7",
+    "display": "Step Count"
+  }
+]

--- a/apps/cardiovascular-health/src/app/datasets/observations.service.ts
+++ b/apps/cardiovascular-health/src/app/datasets/observations.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { CodeableConcept, Coding, Observation } from 'fhir/r4';
-import { DataLayerService, FhirDataService, FhirConverter, FhirCodeService } from '@elimuinformatics/ngx-charts-on-fhir';
+import { DataLayerService, FhirDataService, FhirConverter, FhirCodeService, codeIn } from '@elimuinformatics/ngx-charts-on-fhir';
 import { from, mergeMap } from 'rxjs';
 
 const observationCodings = [
@@ -64,9 +64,7 @@ const observationCodings = [
 @Injectable({ providedIn: 'root' })
 export class CustomFhirCodeService extends FhirCodeService {
   override getName(code: CodeableConcept): string {
-    const codingMatch = observationCodings.find((candidate) =>
-      code.coding?.some((coding) => coding.system === candidate.system && coding.code === candidate.code)
-    );
+    const codingMatch = observationCodings.find(codeIn(code));
     if (codingMatch) {
       return codingMatch?.display;
     }

--- a/apps/cardiovascular-health/src/app/datasets/observations.service.ts
+++ b/apps/cardiovascular-health/src/app/datasets/observations.service.ts
@@ -62,15 +62,15 @@ const observationCodings = [
 ];
 
 @Injectable({ providedIn: 'root' })
-export class CustomFhirCodeService implements FhirCodeService {
-  getName(code: CodeableConcept): string {
+export class CustomFhirCodeService extends FhirCodeService {
+  override getName(code: CodeableConcept): string {
     const codingMatch = observationCodings.find((candidate) =>
       code.coding?.some((coding) => coding.system === candidate.system && coding.code === candidate.code)
     );
     if (codingMatch) {
       return codingMatch?.display;
     }
-    return code.text ?? '';
+    return super.getName(code);
   }
 }
 

--- a/apps/cardiovascular-health/src/app/datasets/observations.service.ts
+++ b/apps/cardiovascular-health/src/app/datasets/observations.service.ts
@@ -2,64 +2,7 @@ import { Injectable } from '@angular/core';
 import { CodeableConcept, Coding, Observation } from 'fhir/r4';
 import { DataLayerService, FhirDataService, FhirConverter, FhirCodeService, codeIn } from '@elimuinformatics/ngx-charts-on-fhir';
 import { from, mergeMap } from 'rxjs';
-
-const observationCodings = [
-  {
-    system: 'http://loinc.org',
-    code: '29463-7',
-    display: 'Body Weight',
-  },
-  {
-    system: 'http://loinc.org',
-    code: '85354-9',
-    display: 'Blood Pressure',
-  },
-  {
-    system: 'http://loinc.org',
-    code: '8480-6',
-    display: 'Systolic',
-  },
-  {
-    system: 'http://loinc.org',
-    code: '8462-4',
-    display: 'Diastolic',
-  },
-  {
-    system: 'http://loinc.org',
-    code: '8867-4',
-    display: 'Heart Rate',
-  },
-  {
-    system: 'http://loinc.org',
-    code: '74774-1',
-    display: 'Glucose',
-  },
-  {
-    system: 'http://loinc.org',
-    code: '2339-0',
-    display: 'Glucose',
-  },
-  {
-    system: 'http://loinc.org',
-    code: '4548-4',
-    display: 'Hemoglobin A1c',
-  },
-  {
-    system: 'http://loinc.org',
-    code: '59408-5',
-    display: 'O2 Saturation',
-  },
-  {
-    system: 'http://loinc.org',
-    code: '55423-8',
-    display: 'Step Count',
-  },
-  {
-    system: 'http://loinc.org',
-    code: '41950-7',
-    display: 'Step Count',
-  },
-];
+import observationCodings from './observations.json';
 
 @Injectable({ providedIn: 'root' })
 export class CustomFhirCodeService extends FhirCodeService {

--- a/apps/cardiovascular-health/src/app/datasets/observations.service.ts
+++ b/apps/cardiovascular-health/src/app/datasets/observations.service.ts
@@ -1,69 +1,75 @@
 import { Injectable } from '@angular/core';
-import { Observation } from 'fhir/r4';
-import { DataLayerService, FhirDataService, FhirConverter } from '@elimuinformatics/ngx-charts-on-fhir';
+import { CodeableConcept, Coding, Observation } from 'fhir/r4';
+import { DataLayerService, FhirDataService, FhirConverter, FhirCodeService } from '@elimuinformatics/ngx-charts-on-fhir';
 import { from, mergeMap } from 'rxjs';
 
-interface Coding {
-  system?: string;
-  code?: string;
-  display?: string;
+const observationCodings = [
+  {
+    system: 'http://loinc.org',
+    code: '29463-7',
+    display: 'Body Weight',
+  },
+  {
+    system: 'http://loinc.org',
+    code: '85354-9',
+    display: 'Blood Pressure',
+  },
+  {
+    system: 'http://loinc.org',
+    code: '8867-4',
+    display: 'Heart Rate',
+  },
+  {
+    system: 'http://loinc.org',
+    code: '74774-1',
+    display: 'Glucose',
+  },
+  {
+    system: 'http://loinc.org',
+    code: '2339-0',
+    display: 'Glucose',
+  },
+  {
+    system: 'http://loinc.org',
+    code: '4548-4',
+    display: 'Hemoglobin A1c',
+  },
+  {
+    system: 'http://loinc.org',
+    code: '59408-5',
+    display: 'O2 Saturation',
+  },
+  {
+    system: 'http://loinc.org',
+    code: '55423-8',
+    display: 'Step Count',
+  },
+  {
+    system: 'http://loinc.org',
+    code: '41950-7',
+    display: 'Step Count',
+  },
+];
+
+@Injectable({ providedIn: 'root' })
+export class CustomFhirCodeService implements FhirCodeService {
+  getName(code: CodeableConcept): string {
+    const codingMatch = observationCodings.find((candidate) =>
+      code.coding?.some((coding) => coding.system === candidate.system && coding.code === candidate.code)
+    );
+    if (codingMatch) {
+      return codingMatch?.display;
+    }
+    return code.text ?? '';
+  }
 }
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable({ providedIn: 'root' })
 export class ObservationLayerService extends DataLayerService {
-  codings: Coding[] = [
-    {
-      system: 'http://loinc.org',
-      code: '29463-7',
-      display: 'Body Weight',
-    },
-    {
-      system: 'http://loinc.org',
-      code: '85354-9',
-      display: 'Blood Pressure',
-    },
-    {
-      system: 'http://loinc.org',
-      code: '8867-4',
-      display: 'Heart rate',
-    },
-    {
-      system: 'http://loinc.org',
-      code: '55423-8',
-      display: 'Pedometer tracking panel',
-    },
-    {
-      system: 'http://loinc.org',
-      code: '74774-1',
-      display: 'Glucose [Mass/volume] in Serum, Plasma or Blood',
-    },
-    {
-      system: 'http://loinc.org',
-      code: '2339-0',
-      display: 'Glucose',
-    },
-    {
-      system: 'http://loinc.org',
-      code: '4548-4',
-      display: 'Hemoglobin A1c/Hemoglobin.total in Blood',
-    },
-    {
-      system: 'http://loinc.org',
-      code: '59408-5',
-      display: 'Oxygen saturation in Arterial blood by Pulse oximetry',
-    },
-    {
-      system: 'http://loinc.org',
-      code: '41950-7',
-      display: 'Number of steps in 24 hour Measured',
-    },
-  ];
   query: string = '';
   constructor(private fhir: FhirDataService, private converter: FhirConverter) {
     super();
-    this.query = this.getQueryfromCoding(this.codings);
+    this.query = this.getQueryfromCoding(observationCodings);
   }
   name = 'Observations';
 

--- a/apps/cardiovascular-health/src/app/datasets/observations.service.ts
+++ b/apps/cardiovascular-health/src/app/datasets/observations.service.ts
@@ -16,6 +16,16 @@ const observationCodings = [
   },
   {
     system: 'http://loinc.org',
+    code: '8480-6',
+    display: 'Systolic',
+  },
+  {
+    system: 'http://loinc.org',
+    code: '8462-4',
+    display: 'Diastolic',
+  },
+  {
+    system: 'http://loinc.org',
     code: '8867-4',
     display: 'Heart Rate',
   },

--- a/apps/cardiovascular-health/src/app/providers/mapper-providers.ts
+++ b/apps/cardiovascular-health/src/app/providers/mapper-providers.ts
@@ -2,10 +2,12 @@ import {
   BloodPressureMapper,
   ComponentObservationMapper,
   DurationMedicationMapper,
+  FhirCodeService,
   Mapper,
   SimpleMedicationMapper,
   SimpleObservationMapper,
 } from '@elimuinformatics/ngx-charts-on-fhir';
+import { CustomFhirCodeService } from '../datasets/observations.service';
 
 /**
  * Resource Mappers for FhirConverter, listed in priority order.
@@ -17,4 +19,5 @@ export const mapperProviders = [
   { provide: Mapper, useExisting: SimpleObservationMapper, multi: true },
   { provide: Mapper, useExisting: DurationMedicationMapper, multi: true },
   { provide: Mapper, useExisting: SimpleMedicationMapper, multi: true },
+  { provide: FhirCodeService, useExisting: CustomFhirCodeService },
 ];

--- a/libs/ngx-charts-on-fhir/src/index.ts
+++ b/libs/ngx-charts-on-fhir/src/index.ts
@@ -34,6 +34,7 @@ export * from './lib/data-layer/data-layer-manager.service';
 export * from './lib/data-layer/data-layer-merge.service';
 export * from './lib/data-layer/data-layer-color.service';
 export * from './lib/data-layer/data-layer';
+export * from './lib/fhir-mappers/fhir-code.service';
 export * from './lib/fhir-mappers/fhir-converter.service';
 export * from './lib/fhir-mappers/multi-mapper.service';
 export * from './lib/fhir-mappers/fhir-mapper-options';

--- a/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-color.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-color.service.ts
@@ -94,8 +94,7 @@ export class DataLayerColorService {
     if (layer.annotations && dataset.label) {
       for (let annotation of layer.annotations) {
         const anno = annotation as BoxAnnotationOptions;
-        const label = anno.label?.content;
-        if (typeof label === 'string' && dataset.chartsOnFhir?.group && label.startsWith(dataset.chartsOnFhir?.group)) {
+        if (anno.id === dataset.chartsOnFhir?.referenceRangeAnnotation) {
           anno.backgroundColor = this.addTransparency(this.getColor(dataset));
         }
       }

--- a/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer.ts
@@ -25,15 +25,22 @@ export type DataLayer<T extends ChartType = TimelineChartType, D = TimelineDataP
 export type Dataset<T extends ChartType = TimelineChartType, D = TimelineDataPoint[]> = ChartDataset<T, D> & {
   /** Custom chart options for Charts-on-FHIR */
   chartsOnFhir?: {
+    /** Datasets in the same group will be assigned the same color and will be combined in statistical calculations */
+    group?: string;
+    /** When set to 'light', `DataLayerColorService` will use a lighter palette when choosing a color for this dataset. */
+    colorPalette?: 'light' | 'dark';
     /**
      * When set to `transparent`, `DataLayerColorService` will apply partial transparency to the fill color of points.
      * When set to `solid` (default), the same color will be used for both stroke and fill colors.
      */
-    group?: string;
-    colorPalette?: string;
     backgroundStyle?: 'solid' | 'transparent';
     /** Tags can be used to apply similar visual style to multiple datasets */
     tags?: string[];
+    /**
+     * ID of the Reference Range Annotation for this dataset.
+     * The annotation will be assigned a matching color and the Reference Range will be used in some statistical calculations.
+     */
+    referenceRangeAnnotation?: string;
   };
 };
 

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/statistics.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/statistics.service.spec.ts
@@ -1,9 +1,8 @@
-import { findReferenceRangeForDataset } from './statistics.service';
+import { StatisticsService, findReferenceRangeForDataset } from './statistics.service';
 import { ScatterDataPoint } from 'chart.js';
 import { DeepPartial } from 'chart.js/dist/types/utils';
 import { AnnotationOptions } from 'chartjs-plugin-annotation';
 import { DataLayer, Dataset, TimelineChartType } from '../data-layer/data-layer';
-import { StatisticsService } from './statistics.service';
 
 describe('StatisticsService', () => {
   let service: StatisticsService;
@@ -24,12 +23,15 @@ describe('StatisticsService', () => {
               { x: new Date('2022-01-02').getTime(), y: 3 },
               { x: new Date('2022-01-03').getTime(), y: 5 },
             ],
+            chartsOnFhir: {
+              referenceRangeAnnotation: 'test-ref-range',
+            },
           },
         ],
         scale: { id: 'test' },
         annotations: [
           {
-            label: { content: 'Test Reference Range' },
+            id: 'test-ref-range',
             yMin: 2,
             yMax: 4,
             yScaleID: 'Scale',
@@ -60,12 +62,15 @@ describe('StatisticsService', () => {
               { x: new Date('2022-01-02').getTime(), y: 3 },
               { x: new Date('2022-01-03').getTime(), y: 5 },
             ],
+            chartsOnFhir: {
+              referenceRangeAnnotation: 'test-ref-range',
+            },
           },
         ],
         scale: { id: 'test' },
         annotations: [
           {
-            label: { content: 'Test Reference Range' },
+            id: 'test-ref-range',
             yMin: 2,
             yMax: 4,
             yScaleID: 'Scale',
@@ -127,6 +132,9 @@ describe('StatisticsService', () => {
               { x: new Date('2022-01-02').getTime(), y: 3 },
               { x: new Date('2022-01-03').getTime(), y: 5 },
             ],
+            chartsOnFhir: {
+              referenceRangeAnnotation: 'one-ref-range',
+            },
           },
           {
             label: 'Two',
@@ -135,18 +143,21 @@ describe('StatisticsService', () => {
               { x: new Date('2022-01-02').getTime(), y: 13 },
               { x: new Date('2022-01-03').getTime(), y: 15 },
             ],
+            chartsOnFhir: {
+              referenceRangeAnnotation: 'two-ref-range',
+            },
           },
         ],
         scale: { id: 'test' },
         annotations: [
           {
-            label: { content: 'One Reference Range' },
+            id: 'one-ref-range',
             yMin: 2,
             yMax: 4,
             yScaleID: 'Scale',
           },
           {
-            label: { content: 'Two Reference Range' },
+            id: 'two-ref-range',
             yMin: 12,
             yMax: 16,
             yScaleID: 'Scale',
@@ -205,16 +216,21 @@ describe('StatisticsService', () => {
 
   describe('findReferenceRangeForDataset', () => {
     it("should return true for dataset's reference range", () => {
-      const dataset: Dataset = { label: 'Test Dataset', data: [] };
+      const dataset: Dataset = {
+        label: 'Test Dataset',
+        data: [],
+        chartsOnFhir: {
+          referenceRangeAnnotation: 'test-ref-range',
+        },
+      };
       const annotations: DeepPartial<AnnotationOptions>[] = [
-        { label: { content: 'Test Reference Range' }, xScaleID: 'x-axis', yScaleID: 'y-axis', value: 10 },
-        { label: { content: 'Reference Range' }, xScaleID: 'x-axis', yScaleID: 'y-axis', yMin: 20, yMax: 30 },
-        { label: { content: 'Test Dataset Reference Range' }, xScaleID: 'x-axis', yScaleID: 'y-axis', yMin: 40, yMax: 50 },
+        { id: 'wrong', label: { content: 'Wrong Reference Range' }, xScaleID: 'x-axis', yScaleID: 'y-axis', yMin: 20, yMax: 30 },
+        { id: 'test-ref-range', label: { content: 'Test Dataset Reference Range' }, xScaleID: 'x-axis', yScaleID: 'y-axis', yMin: 40, yMax: 50 },
       ];
       const result: DeepPartial<AnnotationOptions> | undefined = findReferenceRangeForDataset(annotations, dataset);
-      expect(result).toEqual(annotations[2]);
+      expect(result).toEqual(annotations[1]);
     });
-    it('should return undefine for other annotation', () => {
+    it('should return undefined for other annotation', () => {
       const dataset: Dataset = { label: 'Test', data: [] };
       const annotations: DeepPartial<AnnotationOptions>[] = [
         { label: { content: 'Reference Range' }, xScaleID: 'x-axis', yScaleID: 'y-axis', yMin: 20, yMax: 30 },
@@ -236,12 +252,15 @@ describe('StatisticsService', () => {
               { x: new Date('2022-01-02').getTime(), y: 3 },
               { x: new Date('2022-01-03').getTime(), y: 5 },
             ],
+            chartsOnFhir: {
+              referenceRangeAnnotation: 'test-ref-range',
+            },
           },
         ],
         scale: { id: 'test' },
         annotations: [
           {
-            label: { content: 'Test Reference Range' },
+            id: 'test-ref-range',
             yMin: 2,
             yMax: 4,
             yScaleID: 'Scale',

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/statistics.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/statistics.service.ts
@@ -183,7 +183,8 @@ function getDay(point: ScatterDataPoint): string {
 function isReferenceRangeFor(dataset: Dataset) {
   return function isReferenceRange(annotation: DeepPartial<AnnotationOptions>): annotation is ReferenceRange {
     return (
-      annotation.id === dataset.chartsOnFhir?.referenceRangeAnnotation &&
+      dataset.chartsOnFhir?.referenceRangeAnnotation != null &&
+      annotation.id === dataset.chartsOnFhir.referenceRangeAnnotation &&
       typeof annotation.yMax === 'number' &&
       typeof annotation.yMin === 'number' &&
       typeof annotation.yScaleID === 'string'

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/statistics.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/statistics.service.ts
@@ -1,11 +1,10 @@
 import { Injectable } from '@angular/core';
 import { mean, groupBy, uniq } from 'lodash-es';
 import { ScatterDataPoint } from 'chart.js';
-import { AnnotationOptions, BoxAnnotationOptions } from 'chartjs-plugin-annotation';
+import { AnnotationOptions } from 'chartjs-plugin-annotation';
 import { DataLayer, Dataset } from '../data-layer/data-layer';
 import { NumberRange, isValidScatterDataPoint, MILLISECONDS_PER_DAY, isDefined, ChartAnnotations } from '../utils';
 import { DeepPartial } from 'chart.js/dist/types/utils';
-import { getOriginalLabel } from './home-measurement-summary.service';
 
 type Stats = {
   days: number;

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/statistics.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/statistics.service.ts
@@ -181,10 +181,9 @@ function getDay(point: ScatterDataPoint): string {
 
 /** Factory for generating functions that check if any given annotation is a reference range for the bound dataset */
 function isReferenceRangeFor(dataset: Dataset) {
-  const datasetLabel = getOriginalLabel(dataset);
   return function isReferenceRange(annotation: DeepPartial<AnnotationOptions>): annotation is ReferenceRange {
     return (
-      (annotation as BoxAnnotationOptions)?.label?.content === `${datasetLabel} Reference Range` &&
+      annotation.id === dataset.chartsOnFhir?.referenceRangeAnnotation &&
       typeof annotation.yMax === 'number' &&
       typeof annotation.yMin === 'number' &&
       typeof annotation.yScaleID === 'string'

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.spec.ts
@@ -460,10 +460,14 @@ describe('FhirChartConfigurationService', () => {
         { x: 10, y: 100 },
         { x: 20, y: 200 },
       ],
+      chartsOnFhir: {
+        referenceRangeAnnotation: 'test-ref-range',
+      },
     };
     const scale = { id: 'scale', type: 'linear' } as const;
     const annotations: ChartAnnotations = [
       {
+        id: 'test-ref-range',
         label: { content: 'Test Reference Range' },
         yScaleID: 'scale',
         yMax: 20,

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/fhir-code.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/fhir-code.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed } from '@angular/core/testing';
+import { FhirCodeService } from './fhir-code.service';
+
+describe('CodeNameService', () => {
+  let service: FhirCodeService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(FhirCodeService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/fhir-code.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/fhir-code.service.spec.ts
@@ -9,7 +9,9 @@ describe('CodeNameService', () => {
     service = TestBed.inject(FhirCodeService);
   });
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
+  describe('getName', () => {
+    it('should return text property', () => {
+      expect(service.getName({ text: 'hello' })).toBe('hello');
+    });
   });
 });

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/fhir-code.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/fhir-code.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@angular/core';
+import { CodeableConcept } from 'fhir/r4';
+
+@Injectable({ providedIn: 'root' })
+export class FhirCodeService {
+  getName(code: CodeableConcept): string {
+    return code.text ?? '';
+  }
+}

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/fhir-code.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/fhir-code.service.ts
@@ -20,7 +20,7 @@ import { CodeableConcept, Coding } from 'fhir/r4';
  *       },
  *       // ...
  *     ];
- *     const codingMatch = customCodings.find(codeIn(code));;
+ *     const codingMatch = customCodings.find(codeIn(code));
  *     if (codingMatch) {
  *       return codingMatch?.display;
  *     }

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/fhir-code.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/fhir-code.service.ts
@@ -1,6 +1,47 @@
 import { Injectable } from '@angular/core';
 import { CodeableConcept } from 'fhir/r4';
 
+/**
+ * A service for getting the display name of a FHIR `CodableConcept`.
+ * The default implementation just returns the `text` property.
+ *
+ * @usageNotes
+ * Applications can extend this service to customize the labels associated with specific codes.
+ * For example:
+ * ```ts
+ * @Injectable({ providedIn: 'root' })
+ * export class CustomFhirCodeService extends FhirCodeService {
+ *   getName(code: CodeableConcept): string {
+ *     const customCodings = [
+ *       {
+ *         system: 'http://loinc.org',
+ *         code: '85354-9',
+ *         display: 'Custom Blood Pressure',
+ *       },
+ *       // ...
+ *     ];
+ *     const codingMatch = customCodings.find((candidate) =>
+ *       code.coding?.some((coding) => coding.system === candidate.system && coding.code === candidate.code)
+ *     );
+ *     if (codingMatch) {
+ *       return codingMatch?.display;
+ *     }
+ *     return super.getName(code);
+ *   }
+ * }
+ * ```
+ *
+ * Replace the default implementation by adding the new one to AppModule's providers array:
+ *
+ * ```ts
+ * @NgModule({
+ *   providers: [
+ *     { provide: FhirCodeService, useExisting: CustomFhirCodeService }
+ *   ],
+ * })
+ * export class AppModule {}
+ * ```
+ */
 @Injectable({ providedIn: 'root' })
 export class FhirCodeService {
   getName(code: CodeableConcept): string {

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/medication-request/simple-medication-mapper.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/medication-request/simple-medication-mapper.service.spec.ts
@@ -1,7 +1,19 @@
 import { MedicationRequest } from 'fhir/r4';
 import { SimpleMedication, SimpleMedicationMapper } from './simple-medication-mapper.service';
+import { TestBed } from '@angular/core/testing';
+import { FhirCodeService } from '../fhir-code.service';
+import { MEDICATION_SCALE_OPTIONS } from '../fhir-mapper-options';
 
 describe('SimpleMedicationMapper', () => {
+  let mapper: SimpleMedicationMapper;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [{ provide: MEDICATION_SCALE_OPTIONS, useValue: { type: 'category' } }, FhirCodeService],
+    });
+    mapper = TestBed.inject(SimpleMedicationMapper);
+  });
+
   describe('canMap', () => {
     it('should return true for a SimpleMedication', () => {
       const medication: SimpleMedication = {
@@ -12,7 +24,6 @@ describe('SimpleMedicationMapper', () => {
         status: 'completed',
         subject: {},
       };
-      const mapper = new SimpleMedicationMapper({});
       expect(mapper.canMap(medication)).toBe(true);
     });
 
@@ -24,7 +35,6 @@ describe('SimpleMedicationMapper', () => {
         status: 'completed',
         subject: {},
       };
-      const mapper = new SimpleMedicationMapper({});
       expect(mapper.canMap(medication)).toBe(false);
     });
   });
@@ -40,7 +50,6 @@ describe('SimpleMedicationMapper', () => {
         status: 'completed',
         subject: {},
       };
-      const mapper = new SimpleMedicationMapper({});
       expect(mapper.map(medication).datasets[0].data[0].x).toEqual(date.getTime());
     });
 
@@ -53,7 +62,6 @@ describe('SimpleMedicationMapper', () => {
         status: 'completed',
         subject: {},
       };
-      const mapper = new SimpleMedicationMapper({});
       expect(mapper.map(medication).datasets[0].data[0].y).toEqual('text');
     });
 
@@ -66,7 +74,6 @@ describe('SimpleMedicationMapper', () => {
         status: 'completed',
         subject: {},
       };
-      const mapper = new SimpleMedicationMapper({ type: 'category' });
       expect(mapper.map(medication).scale).toEqual({
         id: 'medications',
         type: 'category',

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/medication-request/simple-medication-mapper.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/medication-request/simple-medication-mapper.service.ts
@@ -6,6 +6,7 @@ import { DataLayer, TimelineChartType, TimelineDataPoint } from '../../data-laye
 import { Mapper } from '../multi-mapper.service';
 import { MEDICATION_SCALE_OPTIONS } from '../fhir-mapper-options';
 import { formatDate } from '../../utils';
+import { FhirCodeService } from '../fhir-code.service';
 
 /** Required properties for mapping a MedicationRequest with `SimpleMedicationMapper` */
 export type SimpleMedication = {
@@ -28,17 +29,18 @@ export type MedicationDataPoint = TimelineDataPoint & {
   providedIn: 'root',
 })
 export class SimpleMedicationMapper implements Mapper<SimpleMedication> {
-  constructor(@Inject(MEDICATION_SCALE_OPTIONS) private medicationScaleOptions: ScaleOptions<'category'>) {}
+  constructor(@Inject(MEDICATION_SCALE_OPTIONS) private medicationScaleOptions: ScaleOptions<'category'>, private codeService: FhirCodeService) {}
   canMap = isMedication;
   map(resource: SimpleMedication): DataLayer<TimelineChartType, MedicationDataPoint[]> {
     const authoredOn = new Date(resource.authoredOn).getTime();
+    const codeName = this.codeService.getName(resource?.medicationCodeableConcept);
     return {
       name: 'Prescribed Medications',
       category: ['medication'],
       datasets: [
         {
           type: 'scatter',
-          label: resource?.medicationCodeableConcept?.text,
+          label: codeName,
           yAxisID: 'medications',
           indexAxis: 'y',
           pointRadius: 10,
@@ -47,7 +49,7 @@ export class SimpleMedicationMapper implements Mapper<SimpleMedication> {
           data: [
             {
               x: authoredOn,
-              y: resource?.medicationCodeableConcept?.text,
+              y: codeName,
               authoredOn: authoredOn,
               tooltip: `Prescribed: ${formatDate(authoredOn)}`,
             },
@@ -64,12 +66,12 @@ export class SimpleMedicationMapper implements Mapper<SimpleMedication> {
       // use annotations for labels so they are drawn on top of the data (axis labels are drawn underneath)
       annotations: [
         {
-          id: resource?.medicationCodeableConcept?.text,
+          id: codeName,
           type: 'line',
           borderWidth: 0,
           label: {
             display: true,
-            content: [resource?.medicationCodeableConcept?.text],
+            content: [codeName],
             position: 'start',
             color: 'black',
             backgroundColor: 'transparent',
@@ -79,7 +81,7 @@ export class SimpleMedicationMapper implements Mapper<SimpleMedication> {
               weight: 'normal',
             },
           },
-          value: resource?.medicationCodeableConcept?.text,
+          value: codeName,
           scaleID: 'medications',
         },
       ],

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/blood-pressure-mapper.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/blood-pressure-mapper.service.spec.ts
@@ -26,7 +26,7 @@ describe('BloodPressureMapper', () => {
       const observation: BloodPressureObservation = {
         resourceType: 'Observation',
         status: 'final',
-        code: { coding: [{ code: '85354-9' }], text: 'Blood Pressure' },
+        code: { coding: [{ system: 'http://loinc.org', code: '85354-9' }], text: 'Blood Pressure' },
         effectiveDateTime: new Date().toISOString(),
         component: [
           {
@@ -42,7 +42,7 @@ describe('BloodPressureMapper', () => {
       const observation: BloodPressureObservation = {
         resourceType: 'Observation',
         status: 'final',
-        code: { coding: [{ code: '8867-4' as any }], text: '' },
+        code: { coding: [{ system: 'http://loinc.org', code: '8867-4' as any }], text: '' },
         effectiveDateTime: new Date().toISOString(),
         component: [
           {
@@ -60,19 +60,36 @@ describe('BloodPressureMapper', () => {
       const observation: BloodPressureObservation = {
         resourceType: 'Observation',
         status: 'final',
-        code: { coding: [{ code: '85354-9' }], text: 'Blood Pressure' },
+        code: { coding: [{ system: 'http://loinc.org', code: '85354-9' }], text: 'Blood Pressure' },
         effectiveDateTime: new Date().toISOString(),
         component: [
           {
-            code: { text: 'component' },
+            code: { coding: [{ system: 'http://loinc.org', code: '8480-6' }], text: 'Systolic' },
+            valueQuantity: { value: 7, unit: 'unit' },
+          },
+          {
+            code: { coding: [{ system: 'http://loinc.org', code: '8462-4' }], text: 'Diastolic' },
             valueQuantity: { value: 7, unit: 'unit' },
           },
         ],
       };
-      expect(mapper.map(observation).annotations).toEqual([
-        jasmine.objectContaining({ label: { content: 'Systolic Reference Range' } }),
-        jasmine.objectContaining({ label: { content: 'Diastolic Reference Range' } }),
-      ]);
+      const layer = mapper.map(observation);
+      const systolicAnnoId = layer.datasets.find((dataset) => dataset.label?.startsWith('Systolic'))?.chartsOnFhir?.referenceRangeAnnotation;
+      const diastolicAnnoId = layer.datasets.find((dataset) => dataset.label?.startsWith('Diastolic'))?.chartsOnFhir?.referenceRangeAnnotation;
+      expect(layer.annotations?.find((anno) => anno.id === systolicAnnoId)).toEqual(
+        jasmine.objectContaining({
+          label: { content: 'Systolic Reference Range' },
+          yMax: 140,
+          yMin: 90,
+        })
+      );
+      expect(layer.annotations?.find((anno) => anno.id === diastolicAnnoId)).toEqual(
+        jasmine.objectContaining({
+          label: { content: 'Diastolic Reference Range' },
+          yMax: 90,
+          yMin: 60,
+        })
+      );
     });
   });
 });

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/blood-pressure-mapper.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/blood-pressure-mapper.service.spec.ts
@@ -2,6 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { TIME_SCALE_OPTIONS, ANNOTATION_OPTIONS, LINEAR_SCALE_OPTIONS } from '../fhir-mapper-options';
 import { BloodPressureMapper, BloodPressureObservation } from './blood-pressure-mapper.service';
 import { ComponentObservationMapper } from './component-observation-mapper.service';
+import { FhirCodeService } from '../fhir-code.service';
 
 describe('BloodPressureMapper', () => {
   let mapper: BloodPressureMapper;
@@ -9,6 +10,7 @@ describe('BloodPressureMapper', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
+        FhirCodeService,
         BloodPressureMapper,
         ComponentObservationMapper,
         { provide: TIME_SCALE_OPTIONS, useValue: {} },
@@ -68,8 +70,8 @@ describe('BloodPressureMapper', () => {
         ],
       };
       expect(mapper.map(observation).annotations).toEqual([
-        jasmine.objectContaining({ label: { content: 'Systolic Blood Pressure Reference Range' } }),
-        jasmine.objectContaining({ label: { content: 'Diastolic Blood Pressure Reference Range' } }),
+        jasmine.objectContaining({ label: { content: 'Systolic Reference Range' } }),
+        jasmine.objectContaining({ label: { content: 'Diastolic Reference Range' } }),
       ]);
     });
   });

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/blood-pressure-mapper.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/blood-pressure-mapper.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { TIME_SCALE_OPTIONS, ANNOTATION_OPTIONS, LINEAR_SCALE_OPTIONS } from '../fhir-mapper-options';
+import { ANNOTATION_OPTIONS, LINEAR_SCALE_OPTIONS } from '../fhir-mapper-options';
 import { BloodPressureMapper, BloodPressureObservation } from './blood-pressure-mapper.service';
 import { ComponentObservationMapper } from './component-observation-mapper.service';
 import { FhirCodeService } from '../fhir-code.service';
@@ -13,7 +13,6 @@ describe('BloodPressureMapper', () => {
         FhirCodeService,
         BloodPressureMapper,
         ComponentObservationMapper,
-        { provide: TIME_SCALE_OPTIONS, useValue: {} },
         { provide: LINEAR_SCALE_OPTIONS, useValue: {} },
         { provide: ANNOTATION_OPTIONS, useValue: {} },
       ],

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/blood-pressure-mapper.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/blood-pressure-mapper.service.ts
@@ -1,9 +1,7 @@
-import { Inject, Injectable } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { Coding, Observation } from 'fhir/r4';
 import { ComponentObservation, ComponentObservationMapper, isComponentObservation } from './component-observation-mapper.service';
 import { Mapper } from '../multi-mapper.service';
-import { ANNOTATION_OPTIONS } from '../fhir-mapper-options';
-import { ChartAnnotation } from '../../utils';
 import { DataLayer } from '../../data-layer/data-layer';
 import { codeEquals } from '../fhir-code.service';
 
@@ -40,7 +38,7 @@ export function isBloodPressureObservation(resource: Observation): resource is B
   providedIn: 'root',
 })
 export class BloodPressureMapper implements Mapper<BloodPressureObservation> {
-  constructor(private baseMapper: ComponentObservationMapper, @Inject(ANNOTATION_OPTIONS) private annotationOptions: ChartAnnotation) {}
+  constructor(private baseMapper: ComponentObservationMapper) {}
   canMap = isBloodPressureObservation;
   map(resource: BloodPressureObservation): DataLayer {
     for (let component of resource.component) {

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/blood-pressure-mapper.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/blood-pressure-mapper.service.ts
@@ -27,17 +27,17 @@ export class BloodPressureMapper implements Mapper<BloodPressureObservation> {
     const layer = this.baseMapper.map(resource);
     layer.annotations = [
       merge({}, this.annotationOptions, {
-        id: 'Systolic Blood Pressure Reference Range',
+        id: 'Systolic Reference Range',
         display: true,
-        label: { content: 'Systolic Blood Pressure Reference Range' },
+        label: { content: 'Systolic Reference Range' },
         yScaleID: layer.datasets[0].yAxisID,
         yMax: 140,
         yMin: 90,
       }),
       merge({}, this.annotationOptions, {
-        id: 'Diastolic Blood Pressure Reference Range',
+        id: 'Diastolic Reference Range',
         display: true,
-        label: { content: 'Diastolic Blood Pressure Reference Range' },
+        label: { content: 'Diastolic Reference Range' },
         yScaleID: layer.datasets[0].yAxisID,
         yMax: 90,
         yMin: 60,

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/blood-pressure-mapper.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/blood-pressure-mapper.service.ts
@@ -1,21 +1,40 @@
 import { Inject, Injectable } from '@angular/core';
-import { merge } from 'lodash-es';
 import { Coding, Observation } from 'fhir/r4';
 import { ComponentObservation, ComponentObservationMapper, isComponentObservation } from './component-observation-mapper.service';
 import { Mapper } from '../multi-mapper.service';
 import { ANNOTATION_OPTIONS } from '../fhir-mapper-options';
 import { ChartAnnotation } from '../../utils';
 import { DataLayer } from '../../data-layer/data-layer';
-const bpCodes = ['85354-9'] as const;
+import { codeEquals } from '../fhir-code.service';
+
+const bpCode = {
+  system: 'http://loinc.org',
+  code: '85354-9',
+  display: 'Blood Pressure',
+} as const;
+
+const systolicCode = {
+  system: 'http://loinc.org',
+  code: '8480-6',
+  display: 'Systolic',
+} as const;
+
+const diastolicCode = {
+  system: 'http://loinc.org',
+  code: '8462-4',
+  display: 'Diastolic',
+} as const;
+
 export type BloodPressureObservation = {
   code: {
     coding: ({
-      code: typeof bpCodes[number];
+      system: typeof bpCode.system;
+      code: typeof bpCode.code;
     } & Coding)[];
   };
 } & ComponentObservation;
 export function isBloodPressureObservation(resource: Observation): resource is BloodPressureObservation {
-  return isComponentObservation(resource) && !!resource.code.coding?.every((c) => bpCodes.includes(c.code as any));
+  return isComponentObservation(resource) && !!codeEquals(resource.code, bpCode);
 }
 @Injectable({
   providedIn: 'root',
@@ -24,25 +43,24 @@ export class BloodPressureMapper implements Mapper<BloodPressureObservation> {
   constructor(private baseMapper: ComponentObservationMapper, @Inject(ANNOTATION_OPTIONS) private annotationOptions: ChartAnnotation) {}
   canMap = isBloodPressureObservation;
   map(resource: BloodPressureObservation): DataLayer {
-    const layer = this.baseMapper.map(resource);
-    layer.annotations = [
-      merge({}, this.annotationOptions, {
-        id: 'Systolic Reference Range',
-        display: true,
-        label: { content: 'Systolic Reference Range' },
-        yScaleID: layer.datasets[0].yAxisID,
-        yMax: 140,
-        yMin: 90,
-      }),
-      merge({}, this.annotationOptions, {
-        id: 'Diastolic Reference Range',
-        display: true,
-        label: { content: 'Diastolic Reference Range' },
-        yScaleID: layer.datasets[0].yAxisID,
-        yMax: 90,
-        yMin: 60,
-      }),
-    ];
-    return layer;
+    for (let component of resource.component) {
+      if (codeEquals(component.code, systolicCode)) {
+        component.referenceRange = [
+          {
+            high: { value: 140 },
+            low: { value: 90 },
+          },
+        ];
+      }
+      if (codeEquals(component.code, diastolicCode)) {
+        component.referenceRange = [
+          {
+            high: { value: 90 },
+            low: { value: 60 },
+          },
+        ];
+      }
+    }
+    return this.baseMapper.map(resource);
   }
 }

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/component-observation-mapper.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/component-observation-mapper.service.spec.ts
@@ -1,7 +1,19 @@
 import { Observation } from 'fhir/r4';
 import { ComponentObservation, ComponentObservationMapper } from './component-observation-mapper.service';
+import { TestBed } from '@angular/core/testing';
+import { FhirCodeService } from '../fhir-code.service';
+import { LINEAR_SCALE_OPTIONS, ANNOTATION_OPTIONS } from '../fhir-mapper-options';
 
 describe('ComponentObservationMapper', () => {
+  let mapper: ComponentObservationMapper;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [{ provide: LINEAR_SCALE_OPTIONS, useValue: { type: 'linear' } }, { provide: ANNOTATION_OPTIONS, useValue: { type: 'box' } }, FhirCodeService],
+    });
+    mapper = TestBed.inject(ComponentObservationMapper);
+  });
+
   describe('canMap', () => {
     it('should return true for a ComponentObservation', () => {
       const observation: ComponentObservation = {
@@ -16,7 +28,6 @@ describe('ComponentObservationMapper', () => {
           },
         ],
       };
-      const mapper = new ComponentObservationMapper({}, {});
       expect(mapper.canMap(observation)).toBe(true);
     });
 
@@ -27,7 +38,6 @@ describe('ComponentObservationMapper', () => {
         code: { text: 'text' },
         effectiveDateTime: new Date().toISOString(),
       };
-      const mapper = new ComponentObservationMapper({}, {});
       expect(mapper.canMap(observation)).toBe(false);
     });
   });
@@ -50,7 +60,6 @@ describe('ComponentObservationMapper', () => {
           },
         ],
       };
-      const mapper = new ComponentObservationMapper({}, {});
       expect(mapper.map(observation).datasets).toEqual([
         jasmine.objectContaining({ label: 'one (Clinic)' }),
         jasmine.objectContaining({ label: 'two (Clinic)' }),
@@ -71,7 +80,6 @@ describe('ComponentObservationMapper', () => {
           },
         ],
       };
-      const mapper = new ComponentObservationMapper({}, {});
       expect(mapper.map(observation).datasets[0].data[0].x).toEqual(date.getTime());
     });
 
@@ -88,7 +96,6 @@ describe('ComponentObservationMapper', () => {
           },
         ],
       };
-      const mapper = new ComponentObservationMapper({}, {});
       expect(mapper.map(observation).datasets[0].data[0].y).toEqual(7);
     });
 
@@ -105,7 +112,6 @@ describe('ComponentObservationMapper', () => {
           },
         ],
       };
-      const mapper = new ComponentObservationMapper({ type: 'linear' }, {});
       expect(mapper.map(observation).scale).toEqual(
         jasmine.objectContaining({
           id: 'text',
@@ -134,7 +140,6 @@ describe('ComponentObservationMapper', () => {
           },
         ],
       };
-      const mapper = new ComponentObservationMapper({}, { type: 'box' });
       expect(mapper.map(observation).annotations?.[0]).toEqual(
         jasmine.objectContaining({
           type: 'box',
@@ -159,7 +164,6 @@ describe('ComponentObservationMapper', () => {
           },
         ],
       };
-      const mapper = new ComponentObservationMapper({}, {});
       expect(mapper.map(observation).category).toEqual(['A', 'B']);
     });
   });

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/component-observation-mapper.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/component-observation-mapper.service.ts
@@ -72,6 +72,7 @@ export class ComponentObservationMapper implements Mapper<ComponentObservation> 
             group: this.codeService.getName(component.code),
             colorPalette: isHomeMeasurement(resource) ? 'light' : 'dark',
             tags: [isHomeMeasurement(resource) ? 'Home' : 'Clinic'],
+            referenceRangeAnnotation: `${this.codeService.getName(component.code)} Reference Range`,
           },
         })),
       scale: merge({}, this.linearScaleOptions, {

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/simple-observation-mapper.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/simple-observation-mapper.service.spec.ts
@@ -1,8 +1,20 @@
 import { Observation } from 'fhir/r4';
 import { HOME_DATASET_LABEL_SUFFIX } from '../../fhir-chart-summary/home-measurement-summary.service';
 import { homeEnvironmentCode, measurementSettingExtUrl, SimpleObservation, SimpleObservationMapper } from './simple-observation-mapper.service';
+import { TestBed } from '@angular/core/testing';
+import { ANNOTATION_OPTIONS, LINEAR_SCALE_OPTIONS } from '../fhir-mapper-options';
+import { FhirCodeService } from '../fhir-code.service';
 
 describe('SimpleObservationMapper', () => {
+  let mapper: SimpleObservationMapper;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [{ provide: LINEAR_SCALE_OPTIONS, useValue: { type: 'linear' } }, { provide: ANNOTATION_OPTIONS, useValue: { type: 'box' } }, FhirCodeService],
+    });
+    mapper = TestBed.inject(SimpleObservationMapper);
+  });
+
   describe('canMap', () => {
     it('should return true for a SimpleObservation', () => {
       const observation: SimpleObservation = {
@@ -12,7 +24,6 @@ describe('SimpleObservationMapper', () => {
         effectiveDateTime: new Date().toISOString(),
         valueQuantity: { value: 7, unit: 'unit' },
       };
-      const mapper = new SimpleObservationMapper({}, {});
       expect(mapper.canMap(observation)).toBe(true);
     });
 
@@ -23,7 +34,6 @@ describe('SimpleObservationMapper', () => {
         code: { text: 'text' },
         effectiveDateTime: new Date().toISOString(),
       };
-      const mapper = new SimpleObservationMapper({}, {});
       expect(mapper.canMap(observation)).toBe(false);
     });
   });
@@ -38,7 +48,6 @@ describe('SimpleObservationMapper', () => {
         effectiveDateTime: date.toISOString(),
         valueQuantity: { value: 7, unit: 'unit' },
       };
-      const mapper = new SimpleObservationMapper({}, {});
       expect(mapper.map(observation).datasets[0].data[0].x).toEqual(date.getTime());
     });
 
@@ -50,7 +59,6 @@ describe('SimpleObservationMapper', () => {
         effectiveDateTime: new Date().toISOString(),
         valueQuantity: { value: 7, unit: 'unit' },
       };
-      const mapper = new SimpleObservationMapper({}, {});
       expect(mapper.map(observation).datasets[0].data[0].y).toEqual(7);
     });
 
@@ -62,7 +70,6 @@ describe('SimpleObservationMapper', () => {
         effectiveDateTime: new Date().toISOString(),
         valueQuantity: { value: 7, unit: 'unit' },
       };
-      const mapper = new SimpleObservationMapper({ type: 'linear' }, {});
       expect(mapper.map(observation).scale).toEqual({
         id: 'text',
         type: 'linear',
@@ -84,7 +91,6 @@ describe('SimpleObservationMapper', () => {
           },
         ],
       };
-      const mapper = new SimpleObservationMapper({}, { type: 'box' });
       expect(mapper.map(observation).annotations?.[0]).toEqual(
         jasmine.objectContaining({
           type: 'box',
@@ -104,7 +110,6 @@ describe('SimpleObservationMapper', () => {
         effectiveDateTime: new Date().toISOString(),
         valueQuantity: { value: 7, unit: 'unit' },
       };
-      const mapper = new SimpleObservationMapper({}, {});
       expect(mapper.map(observation).category).toEqual(['A', 'B']);
     });
 
@@ -124,7 +129,6 @@ describe('SimpleObservationMapper', () => {
           },
         ],
       };
-      const mapper = new SimpleObservationMapper({}, {});
       expect(mapper.map(observation).datasets[0].label).toBe('text' + HOME_DATASET_LABEL_SUFFIX);
     });
   });

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/simple-observation-mapper.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/simple-observation-mapper.service.ts
@@ -7,6 +7,7 @@ import { Mapper } from '../multi-mapper.service';
 import { ChartAnnotation, isDefined } from '../../utils';
 import { LINEAR_SCALE_OPTIONS, ANNOTATION_OPTIONS } from '../fhir-mapper-options';
 import { CLINIC_DATASET_LABEL_SUFFIX, HOME_DATASET_LABEL_SUFFIX } from '../../fhir-chart-summary/home-measurement-summary.service';
+import { FhirCodeService } from '../fhir-code.service';
 
 /** Required properties for mapping an Observation with `SimpleObservationMapper` */
 export type SimpleObservation = {
@@ -36,18 +37,19 @@ export function isSimpleObservation(resource: Observation): resource is SimpleOb
 export class SimpleObservationMapper implements Mapper<SimpleObservation> {
   constructor(
     @Inject(LINEAR_SCALE_OPTIONS) private linearScaleOptions: ScaleOptions<'linear'>,
-    @Inject(ANNOTATION_OPTIONS) private annotationOptions: ChartAnnotation
+    @Inject(ANNOTATION_OPTIONS) private annotationOptions: ChartAnnotation,
+    private codeService: FhirCodeService
   ) {}
   canMap = isSimpleObservation;
   map(resource: SimpleObservation): DataLayer {
-    const scaleName = resource.code.text;
+    const codeName = this.codeService.getName(resource.code);
     return {
-      name: resource.code.text,
+      name: codeName,
       category: resource.category?.flatMap((c) => c.coding?.map((coding) => coding.display)).filter(isDefined),
       datasets: [
         {
-          label: resource.code.text + getMeasurementSettingSuffix(resource),
-          yAxisID: scaleName,
+          label: codeName + getMeasurementSettingSuffix(resource),
+          yAxisID: codeName,
           data: [
             {
               x: new Date(resource.effectiveDateTime).getTime(),
@@ -55,21 +57,21 @@ export class SimpleObservationMapper implements Mapper<SimpleObservation> {
             },
           ],
           chartsOnFhir: {
-            group: resource.code.text,
+            group: codeName,
             colorPalette: isHomeMeasurement(resource) ? 'light' : 'dark',
             tags: [isHomeMeasurement(resource) ? 'Home' : 'Clinic'],
           },
         },
       ],
       scale: merge({}, this.linearScaleOptions, {
-        id: scaleName,
-        title: { text: [scaleName, resource.valueQuantity.unit] },
+        id: codeName,
+        title: { text: [codeName, resource.valueQuantity.unit] },
       }),
       annotations: resource.referenceRange?.map<ChartAnnotation>((range) =>
         merge({}, this.annotationOptions, {
-          id: `${resource.code.text} Reference Range`,
-          label: { content: `${resource.code.text} Reference Range` },
-          yScaleID: scaleName,
+          id: `${codeName} Reference Range`,
+          label: { content: `${codeName} Reference Range` },
+          yScaleID: codeName,
           yMax: range?.high?.value,
           yMin: range?.low?.value,
         })

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/simple-observation-mapper.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/simple-observation-mapper.service.ts
@@ -60,6 +60,7 @@ export class SimpleObservationMapper implements Mapper<SimpleObservation> {
             group: codeName,
             colorPalette: isHomeMeasurement(resource) ? 'light' : 'dark',
             tags: [isHomeMeasurement(resource) ? 'Home' : 'Clinic'],
+            referenceRangeAnnotation: `${codeName} Reference Range`,
           },
         },
       ],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -20,6 +20,7 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "importHelpers": true,
+    "resolveJsonModule": true,
     "esModuleInterop": true,
     "target": "ES2022",
     "module": "es2020",


### PR DESCRIPTION
## Overview

- Added `FhirCodeService`, which is responsible for returning the name of a CodeableConcept
- The default implementation simply returns `code.text`
- Built-in mappers now call `FhirCodeService.getName()` instead of using `code.text`
- Cardiovascular-health app now provides a custom FhirCodeService that replaces some of the names with ones that are shorter and more consistent
- Added some utility functions for comparing FHIR codes
- Changed reference range annotation matching code so it uses the new `chartsOnFhir.referenceRangeAnnotation` property on the dataset object instead of using the dataset label. Now the annotations will be matched correctly after customizing the dataset labels.
- Rewrote `BloodPressureMapper` so it passes a modified resource to the `ComponentObservationMapper` instead of modifying the layer afterwards.

## How it was tested

- Ran showcase and cardio apps locally.
- Checked that all layer and dataset names display correctly on chart, tooltips, summary cards, and data-layer-list
- Checked that annotation colors match the corresponding dataset
- Checked that summary component displays correct values for BP card, including Out Of Range

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [x] I have included screen shots for changes that affect the user interface
- [x] I have updated unit tests
- [x] I have run unit tests locally
- [x] I have updated documentation (including README)
