### PR TITLE
RT-755-Promises-must-be-awaited

### DIFF
--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-layout/fhir-chart-layout.component.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-layout/fhir-chart-layout.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { MatSidenav } from '@angular/material/sidenav';
+import { from, lastValueFrom } from 'rxjs';
 import { ToolbarButtonName } from '../data-layer-toolbar/data-layer-toolbar/data-layer-toolbar.component';
 import { FhirDataService } from '../fhir-data/fhir-data.service';
 
@@ -18,12 +19,12 @@ export class FhirChartLayoutComponent {
 
   constructor(public fhir: FhirDataService) {}
 
-  onToolbarChange(sidenav: MatSidenav, panel: ToolbarButtonName | null) {
+  async onToolbarChange(sidenav: MatSidenav, panel: ToolbarButtonName | null) {
     if (panel) {
       this.active = panel;
-      sidenav.open();
+      await lastValueFrom(from(sidenav.open()));
     } else {
-      sidenav.close();
+      await lastValueFrom(from(sidenav.close()));
     }
   }
 }


### PR DESCRIPTION
## Overview
Use async await for handling promises.
Update the code for handling promises in `fhir-chart-layout.component.ts`.
toPromise() method is deprecated so used `lastValueFrom()` method to handle it.


## How it was tested
Tested using run showcase app locally.


## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
