### PR TITLE
Disable autoEnable and autoSelect on layer update

### DIFF
--- a/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-manager.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-manager.service.ts
@@ -240,7 +240,8 @@ export class DataLayerManagerService {
   }
 
   /** Modify a layer's properties.
-   * This method must be used to propagate the changes to other components.
+   * If the layer's `selected` property is changed, this will disable auto-select.
+   * If the layer's `enabled` or `dataset[].hidden` property is changed, this will disable auto-enable.
    */
   update(layer: ManagedDataLayer) {
     if (!this.state.layers[layer.id]) {

--- a/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-manager.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-manager.service.ts
@@ -246,9 +246,24 @@ export class DataLayerManagerService {
     if (!this.state.layers[layer.id]) {
       throw new Error(`Layer [${layer.id}] not found`);
     }
-    this.state = produce(this.state, (draft) => {
+    let nextState = produce(this.state, (draft) => {
       draft.layers[layer.id] = castDraft(layer);
     });
+    const old = this.state.layers[layer.id];
+    if (layer.selected !== old.selected) {
+      nextState = {
+        ...nextState,
+        ...(layer.selected ? this.selectLayer(nextState, layer.id) : this.removeLayer(nextState, layer.id)),
+        autoSelectFn: undefined,
+      };
+    }
+    if (layer.enabled !== old.enabled || layer.datasets.some((d, i) => d.hidden !== old.datasets[i].hidden)) {
+      nextState = {
+        ...nextState,
+        autoEnableFn: undefined,
+      };
+    }
+    this.state = nextState;
   }
 
   /** Change the sort order of a layer. This will disable auto-sort. */


### PR DESCRIPTION
## Overview

This PR fixes a bug with lines not getting hidden when the dataset is unchecked in dataset-list component

Changes to DataLayerManagerService:
- Disable `autoEnable` when `update()` changes `dataset.hidden` or `layer.enabled`
- Disable `autoSelect` and select/remove layer when `update()` changes `layer.selected`

## How it was tested

- Ran cardio app, checked/unchecked datasets and layers from options panel and made sure the chart updates correctly.
- Wrote some more unit tests

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [x] I have updated unit tests
- [x] I have run unit tests locally
- [x] I have updated documentation (including README)
