### PR TITLE
RT-736-Medication-summary-card-first-written-date

### DIFF
--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/medication-summary.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/medication-summary.service.spec.ts
@@ -48,7 +48,8 @@ describe('MedicationSummaryService', () => {
       expect(summary).toEqual([
         {
           Medications: 'one',
-          'Date Written': '1 Jan 2023',
+          'First Written': '1 Jan 2023',
+          'Last Written': '1 Jan 2023',
         },
       ]);
     });

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/medication-summary.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/medication-summary.service.ts
@@ -14,7 +14,8 @@ export class MedicationSummaryService implements SummaryService {
   summarize(layer: DataLayer<TimelineChartType, MedicationDataPoint[]>): Record<string, string>[] {
     return layer.datasets.map((dataset) => ({
       [layer.name]: dataset.label ?? '(unknown)',
-      'Date Written': formatDate(Math.max(...dataset.data.map((point) => point.authoredOn))),
+      'First Written': formatDate(Math.min(...dataset.data.map((point) => point.authoredOn))),
+      'Last Written': formatDate(Math.max(...dataset.data.map((point) => point.authoredOn))),
     }));
   }
 }


### PR DESCRIPTION
## Overview
In the medication summary card change the column label `Date Written` to `Last Written`.
Calculate the `First Written` Date based on `authoredOn` and display it in the medication summary card.
Update Test cases according to changes.
![image](https://user-images.githubusercontent.com/117890382/236233521-ffbae2c5-8ab9-4c1f-8fa8-51967e0251bd.png)

## How it was tested
Tested using run showcase and cardio-health-app locally.


## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [x] I have included screen shots for changes that affect the user interface
- [x] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
