### PR TITLE
Smooth animations while data is loading

### DIFF
--- a/apps/cardiovascular-health/src/app/datasets/observations.service.ts
+++ b/apps/cardiovascular-health/src/app/datasets/observations.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { CodeableConcept, Coding, Observation } from 'fhir/r4';
 import { DataLayerService, FhirDataService, FhirConverter, FhirCodeService, codeIn } from '@elimuinformatics/ngx-charts-on-fhir';
-import { from, mergeMap } from 'rxjs';
+import { OperatorFunction, bufferCount, concatMap, delay, from, mergeMap, pipe } from 'rxjs';
 import observationCodings from './observations.json';
 
 @Injectable({ providedIn: 'root' })
@@ -25,7 +25,10 @@ export class ObservationLayerService extends DataLayerService {
   name = 'Observations';
 
   retrieve = () => {
-    return this.fhir.getPatientData<Observation>('Observation' + this.query).pipe(mergeMap((bundle) => from(this.converter.convert(bundle))));
+    return this.fhir.getPatientData<Observation>('Observation' + this.query).pipe(
+      mergeMap((bundle) => from(this.converter.convert(bundle))),
+      smoothDataAnimations(50)
+    );
   };
 
   getQueryfromCoding(codings: Coding[]) {
@@ -33,4 +36,17 @@ export class ObservationLayerService extends DataLayerService {
     codings.forEach((coding: any) => (finalUrl += `${coding.system}|${coding.code},`));
     return finalUrl;
   }
+}
+
+/**
+ * Operator function that smooths out animations while adding data to the chart.
+ * delay(0) makes the emission async, allowing the chart to start animating points in the buffer.
+ * Smaller buffer size will give smoother animation, but may impact performance.
+ */
+function smoothDataAnimations<T>(bufferSize: number): OperatorFunction<T, T> {
+  return pipe(
+    bufferCount(bufferSize),
+    delay(0),
+    concatMap((layers) => from(layers))
+  );
 }

--- a/apps/cardiovascular-health/src/app/datasets/observations.service.ts
+++ b/apps/cardiovascular-health/src/app/datasets/observations.service.ts
@@ -34,7 +34,7 @@ export class ObservationLayerService extends DataLayerService {
   getQueryfromCoding(codings: Coding[]) {
     let finalUrl = '?code=';
     codings.forEach((coding: any) => (finalUrl += `${coding.system}|${coding.code},`));
-    return finalUrl;
+    return finalUrl + '&_sort=-date';
   }
 }
 

--- a/apps/documentation/src/app/pages/getting-started/retrieving-data/index.md
+++ b/apps/documentation/src/app/pages/getting-started/retrieving-data/index.md
@@ -19,11 +19,14 @@ export class ObservationLayerService implements DataLayerService {
   name = "Observations";
   retrieve = () => {
     return this.fhir
-      .getPatientData<Observation>("Observation")
+      .getPatientData<Observation>("Observation?_sort=-date")
       .pipe(mergeMap((bundle) => from(this.converter.convert(bundle))));
   };
 }
 ```
+
+> **Note**
+> Note that the FHIR query sorts by date descending. This will retrieve the most recent data first, allowing you to quickly see the most relevant data while `FhirDataService` continues loading older data in the background.
 
 To use this service, provide it as a `DataLayerService` in AppModule:
 

--- a/apps/showcase/src/app/datasets/observations.service.ts
+++ b/apps/showcase/src/app/datasets/observations.service.ts
@@ -12,6 +12,6 @@ export class ObservationLayerService extends DataLayerService {
   }
   name = 'Observations';
   retrieve = () => {
-    return this.fhir.getPatientData<Observation>('Observation').pipe(mergeMap((bundle) => from(this.converter.convert(bundle))));
+    return this.fhir.getPatientData<Observation>('Observation?_sort=-date').pipe(mergeMap((bundle) => from(this.converter.convert(bundle))));
   };
 }

--- a/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-merge.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-merge.service.ts
@@ -61,7 +61,7 @@ export class DataLayerMergeService {
   }
 }
 
-function sortData(a: TimelineDataPoint, b: TimelineDataPoint) {
+export function sortData(a: TimelineDataPoint, b: TimelineDataPoint) {
   return (Array.isArray(a.x) ? a.x[0] : a.x) - (Array.isArray(b.x) ? b.x[0] : b.x);
 }
 

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.spec.ts
@@ -17,6 +17,7 @@ describe('FhirChartConfigurationService', () => {
     data: { datasets: [] },
     options: {
       scales: jasmine.anything(),
+      animation: jasmine.anything(),
       plugins: jasmine.objectContaining({
         annotation: { annotations: jasmine.arrayContaining([jasmine.objectContaining({ scaleID: 'x' })]) },
       }),

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-data/fhir-data.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-data/fhir-data.service.ts
@@ -94,8 +94,7 @@ export class FhirDataService {
           throw new Error('Cancelled by subscriber');
         }
       };
-      // use maximum page size on every request to improve performance
-      url = addCountParam(url);
+      url = addDefaultParams(url);
       const request = currentPatientOnly ? this.client.patient.request.bind(this.client.patient) : this.client.request.bind(this.client);
 
       request(url, { pageLimit: 0, onPage })
@@ -225,14 +224,18 @@ export class FhirDataService {
   }
 }
 
-function addCountParam(url: string) {
+/**
+ * Use maximum page size on every request to improve performance.
+ * Sort by date descending so most recent data is available first.
+ */
+function addDefaultParams(url: string) {
   if (!url.includes('_count=')) {
     if (url.includes('?')) {
       url += '&';
     } else {
       url += '?';
     }
-    url += '_count=200';
+    url += '_count=200&_sort=-date';
   }
   return url;
 }

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-data/fhir-data.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-data/fhir-data.service.ts
@@ -94,7 +94,10 @@ export class FhirDataService {
           throw new Error('Cancelled by subscriber');
         }
       };
-      url = addDefaultParams(url);
+      // use maximum page size on every request to improve performance
+      url = addDefaultParam(url, '_count', '200');
+      // sort by date descending so most recent data is available first
+      url = addDefaultParam(url, '_sort', '-date');
       const request = currentPatientOnly ? this.client.patient.request.bind(this.client.patient) : this.client.request.bind(this.client);
 
       request(url, { pageLimit: 0, onPage })
@@ -224,18 +227,14 @@ export class FhirDataService {
   }
 }
 
-/**
- * Use maximum page size on every request to improve performance.
- * Sort by date descending so most recent data is available first.
- */
-function addDefaultParams(url: string) {
-  if (!url.includes('_count=')) {
+function addDefaultParam(url: string, name: string, value: string) {
+  if (!url.includes(`${name}=`)) {
     if (url.includes('?')) {
       url += '&';
     } else {
       url += '?';
     }
-    url += '_count=200&_sort=-date';
+    url += `${name}=${value}`;
   }
   return url;
 }

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-data/fhir-data.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-data/fhir-data.service.ts
@@ -95,9 +95,7 @@ export class FhirDataService {
         }
       };
       // use maximum page size on every request to improve performance
-      url = addDefaultParam(url, '_count', '200');
-      // sort by date descending so most recent data is available first
-      url = addDefaultParam(url, '_sort', '-date');
+      url = addCountParam(url);
       const request = currentPatientOnly ? this.client.patient.request.bind(this.client.patient) : this.client.request.bind(this.client);
 
       request(url, { pageLimit: 0, onPage })
@@ -227,14 +225,14 @@ export class FhirDataService {
   }
 }
 
-function addDefaultParam(url: string, name: string, value: string) {
-  if (!url.includes(`${name}=`)) {
+function addCountParam(url: string) {
+  if (!url.includes('_count=')) {
     if (url.includes('?')) {
       url += '&';
     } else {
       url += '?';
     }
-    url += `${name}=${value}`;
+    url += '_count=200';
   }
   return url;
 }


### PR DESCRIPTION
## Overview

- Sort FHIR Observation queries in reverse chronological order in all apps so most recent data is loaded first
- When merging new data into a layer, sort in reverse chronological order to avoid shuffling data points animation
- In cardio app, update chart after smaller batches of points to smooth out animations while loading data
- Use quicker default animations so everything feels a bit snappier.

## How it was tested

- Ran cardio and showcase apps and watched the data load.

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [x] I have included screen shots for changes that affect the user interface
- [x] I have updated unit tests
- [x] I have run unit tests locally
- [x] I have updated documentation (including README)
