### PR TITLE
Fix content overflow gradient

### DIFF
--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary-card/fhir-chart-summary-card.component.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary-card/fhir-chart-summary-card.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Inject, Input, Output } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, Inject, Input, Output } from '@angular/core';
 import { FhirChartConfigurationService } from '../../fhir-chart/fhir-chart-configuration.service';
 import { DataLayer } from '../../data-layer/data-layer';
 import { DataLayerColorService } from '../../data-layer/data-layer-color.service';
@@ -33,7 +33,8 @@ export class FhirChartSummaryCardComponent {
     public configService: FhirChartConfigurationService,
     private colorService: DataLayerColorService,
     private elementRef: ElementRef,
-    @Inject(SummaryService) private summaryServices: SummaryService[]
+    @Inject(SummaryService) private summaryServices: SummaryService[],
+    private changeDetectorRef: ChangeDetectorRef
   ) {}
 
   overlayPositions: ConnectionPositionPair[] = [{ originX: 'start', originY: 'top', overlayX: 'start', overlayY: 'top', offsetX: -8 }];
@@ -46,6 +47,21 @@ export class FhirChartSummaryCardComponent {
   }
   get contentOverflow() {
     return this.elementRef.nativeElement.scrollHeight > this.elementRef.nativeElement.offsetHeight;
+  }
+
+  private resizeObserver?: ResizeObserver;
+
+  ngOnInit() {
+    this.resizeObserver = new ResizeObserver(() => {
+      this.changeDetectorRef.markForCheck();
+    });
+    this.resizeObserver.observe(this.elementRef.nativeElement);
+  }
+
+  ngOnDestroy() {
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+    }
   }
 
   getTooltip() {


### PR DESCRIPTION
## Overview

- Use ResizeObserver to trigger change detection when element size changes

## How it was tested

- Ran cardio app, resized browser window and checked that gradient is displayed when card is too small for content.

## Checklist

- [ ] The title contains a short meaningful summary
- [ ] I have added a link to this PR in the Jira issue
- [ ] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)
