### PR TITLE
Fix test-npm-package script

### DIFF
--- a/libs/ngx-charts-on-fhir/test-npm-package.Dockerfile
+++ b/libs/ngx-charts-on-fhir/test-npm-package.Dockerfile
@@ -3,9 +3,11 @@ RUN apk update && apk add jq
 USER node
 WORKDIR /home/node
 COPY ./libs/ngx-charts-on-fhir/test-npm-package.sh ./libs/ngx-charts-on-fhir/
-COPY ./libs/ngx-charts-on-fhir/package*.json ./libs/ngx-charts-on-fhir/
+COPY ./libs/ngx-charts-on-fhir/package.json ./libs/ngx-charts-on-fhir/
 COPY --chown=node ./dist/libs/ngx-charts-on-fhir ./dist/libs/ngx-charts-on-fhir
 RUN ./libs/ngx-charts-on-fhir/test-npm-package.sh
 WORKDIR /home/node/test-app
 ENTRYPOINT []
 CMD ["cat", "package.json"]
+# To run the test app:
+# docker run -p 4200:4200 test-npm-package npm start -- --host 0.0.0.0

--- a/libs/ngx-charts-on-fhir/test-npm-package.Dockerfile
+++ b/libs/ngx-charts-on-fhir/test-npm-package.Dockerfile
@@ -1,4 +1,5 @@
 FROM node:18.13.0-alpine
+RUN apk update && apk add jq
 USER node
 WORKDIR /home/node
 COPY ./libs/ngx-charts-on-fhir/test-npm-package.sh ./libs/ngx-charts-on-fhir/

--- a/libs/ngx-charts-on-fhir/test-npm-package.sh
+++ b/libs/ngx-charts-on-fhir/test-npm-package.sh
@@ -17,6 +17,9 @@ echo ::::: Creating a new Angular app
 npx --yes \@angular/cli@${MIN_ANGULAR_VERSION} new test-app --defaults
 cd test-app
 
+echo ::::: Installing Angular Material
+npx --yes \@angular/cli@${MIN_ANGULAR_VERSION} add @angular/material --skip-confirmation --interactive=false
+
 echo ::::: Installing Charts-on-FHIR library
 npm i ../dist/libs/ngx-charts-on-fhir/${PACKAGE_FILE}
 


### PR DESCRIPTION
## Overview

- test-npm-package script was using the wrong angular version because jq was not installed in docker image
- install angular material in test-npm-package script so it works with angular 15

## How it was tested

- `nx run ngx-charts-on-fhir:test-npm-package`
- verified angular version in script output

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)
