### PR TITLE
Bugfix: Chart configuration service retains old data points

### DIFF
--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.spec.ts
@@ -339,6 +339,74 @@ describe('FhirChartConfigurationService', () => {
         })
       );
     });
+
+    it('should update config when a data point is added', () => {
+      const a: ManagedDataLayer[] = [
+        {
+          name: '1',
+          id: '1',
+          enabled: true,
+          datasets: [{ label: 'one', data: [] }],
+          scale: { id: '1' },
+        },
+      ];
+      const b: ManagedDataLayer[] = [
+        {
+          name: '1',
+          id: '1',
+          enabled: true,
+          datasets: [{ label: 'one', data: [{ x: 1, y: 1 }] }],
+          scale: { id: '1' },
+        },
+      ];
+      const layerManager: any = { selectedLayers$: hot('ab', { a, b }) };
+      const configService = new FhirChartConfigurationService(layerManager, timeScaleOptions, timeframeAnnotationOptions, ngZone);
+      expect(configService.chartConfig$).toBeObservable(
+        hot('xy', {
+          x: jasmine.anything(), // cannot test prior state because it has been mutated
+          y: {
+            ...emptyConfig,
+            data: {
+              datasets: [{ label: 'one', data: [{ x: 1, y: 1 }] }],
+            },
+          },
+        })
+      );
+    });
+
+    it('should update config when a data point is removed', () => {
+      const a: ManagedDataLayer[] = [
+        {
+          name: '1',
+          id: '1',
+          enabled: true,
+          datasets: [{ label: 'one', data: [{ x: 1, y: 1 }] }],
+          scale: { id: '1' },
+        },
+      ];
+      const b: ManagedDataLayer[] = [
+        {
+          name: '1',
+          id: '1',
+          enabled: true,
+          datasets: [{ label: 'one', data: [] }],
+          scale: { id: '1' },
+        },
+      ];
+      const layerManager: any = { selectedLayers$: hot('ab', { a, b }) };
+      const configService = new FhirChartConfigurationService(layerManager, timeScaleOptions, timeframeAnnotationOptions, ngZone);
+      expect(configService.chartConfig$).toBeObservable(
+        hot('xy', {
+          x: jasmine.anything(), // cannot test prior state because it has been mutated
+          y: {
+            ...emptyConfig,
+            data: {
+              datasets: [{ label: 'one', data: [] }],
+            },
+          },
+        })
+      );
+    });
   });
 
   describe('timelineRange$', () => {

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.ts
@@ -198,10 +198,10 @@ export class FhirChartConfigurationService {
 }
 
 /** Customizer function used with lodash `mergeWith` */
-const datasetMergeCustomizer = (objValue: any, srcValue: any, key: any) => {
+const datasetMergeCustomizer = (_objValue: any, srcValue: any, key: any) => {
   if (key === 'data') {
     // sort in reverse order so animation will look better when data is loading in reverse chronological order
-    return union<TimelineDataPoint>(objValue, srcValue).sort((b, a) => sortData(a, b));
+    return srcValue.slice().sort((b: any, a: any) => sortData(a, b));
   }
   return undefined;
 };

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable, NgZone } from '@angular/core';
 import { ChartConfiguration, ScaleOptions, CartesianScaleOptions, Chart, TooltipItem } from 'chart.js';
 import { produce } from 'immer';
-import { mapValues, merge, mergeWith, union } from 'lodash-es';
+import { mapValues, merge, mergeWith } from 'lodash-es';
 import { combineLatest, map, ReplaySubject, scan, tap, throttleTime } from 'rxjs';
 import { TimelineChartType, ManagedDataLayer, Dataset, TimelineDataPoint } from '../data-layer/data-layer';
 import { DataLayerManagerService } from '../data-layer/data-layer-manager.service';


### PR DESCRIPTION
## Overview

- Fixes a bug where `FhirChartConfigurationService` retains old data points that have been removed from the dataset.

## How it was tested

- Added unit test that failed without the fix and passes with the fix
- Ran cardio app and watched the chart while loading data to make sure data points are added properly

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [x] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
