### PR TITLE
Include resource object on chart data points

### DIFF
--- a/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer.ts
@@ -8,6 +8,7 @@ export type TimelineDataPoint = {
   x: number | [number, number];
   y: number | string;
   tooltip?: string | string[];
+  resource?: any;
 };
 
 export type TimelineScaleType = 'linear' | 'category';

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/medication-request/duration-medication-mapper.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/medication-request/duration-medication-mapper.service.ts
@@ -219,6 +219,7 @@ export class DurationMedicationMapper implements Mapper<DurationMedication> {
           y: dataset.data[0].y,
           authoredOn,
           tooltip: [`Prescribed: ${formatDate(authoredOn)}`, `Est. supply: ${durationDays} days`, `Est. end date: ${formatDate(endDate)}`],
+          resource,
         },
       ],
     }));

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/medication-request/simple-medication-mapper.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/medication-request/simple-medication-mapper.service.ts
@@ -52,6 +52,7 @@ export class SimpleMedicationMapper implements Mapper<SimpleMedication> {
               y: codeName,
               authoredOn: authoredOn,
               tooltip: `Prescribed: ${formatDate(authoredOn)}`,
+              resource,
             },
           ],
           chartsOnFhir: {

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/component-observation-mapper.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/component-observation-mapper.service.ts
@@ -64,6 +64,7 @@ export class ComponentObservationMapper implements Mapper<ComponentObservation> 
           {
             x: new Date(resource.effectiveDateTime).getTime(),
             y: component.valueQuantity.value,
+            resource,
           },
         ],
         chartsOnFhir: {

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/simple-observation-mapper.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/simple-observation-mapper.service.ts
@@ -56,6 +56,7 @@ export class SimpleObservationMapper implements Mapper<SimpleObservation> {
             {
               x: new Date(resource.effectiveDateTime).getTime(),
               y: resource.valueQuantity.value,
+              resource,
             },
           ],
           chartsOnFhir: {


### PR DESCRIPTION
## Overview

- Adds the raw FHIR resource as a property on each data point, so apps can work with the raw data (e.g. to display additional information) without maintaining their own state.

## How it was tested

- Ran cardio app and did a quick regression test
- Temporarily added onClick handler that logged raw resources to console

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
