### PR TITLE
RT-890:Hide summary range lines

### DIFF
--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.spec.ts
@@ -19,7 +19,7 @@ class MockLifecycleService {
 }
 
 class MockFhirChartConfigurationService {
-  showSummaryRange = () => {};
+  setSummaryRange = () => {};
 }
 
 @Component({ selector: 'fhir-chart-summary-card' })

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.spec.ts
@@ -8,6 +8,7 @@ import { FhirChartSummaryComponent } from './fhir-chart-summary.component';
 import { FhirChartLifecycleService } from '../../fhir-chart/fhir-chart-lifecycle.service';
 import { Chart } from 'chart.js';
 import { DeepPartial } from 'chart.js/dist/types/utils';
+import { FhirChartConfigurationService } from '../../fhir-chart/fhir-chart-configuration.service';
 
 class MockLayerManager {
   enabledLayers$ = new BehaviorSubject<ManagedDataLayer[]>([]);
@@ -15,6 +16,10 @@ class MockLayerManager {
 
 class MockLifecycleService {
   afterUpdate$ = new Subject<[DeepPartial<Chart>]>();
+}
+
+class MockFhirChartConfigurationService {
+  showSummaryRange = () => {};
 }
 
 @Component({ selector: 'fhir-chart-summary-card' })
@@ -30,15 +35,18 @@ describe('FhirChartSummaryComponent', () => {
   let fixture: ComponentFixture<FhirChartSummaryComponent>;
   let layerManager: MockLayerManager;
   let lifecycleService: MockLifecycleService;
+  let fhirChartConfigurationService: MockFhirChartConfigurationService;
 
   beforeEach(async () => {
     layerManager = new MockLayerManager();
     lifecycleService = new MockLifecycleService();
+    fhirChartConfigurationService = new MockFhirChartConfigurationService();
     await TestBed.configureTestingModule({
       declarations: [FhirChartSummaryComponent, MockFhirChartSummaryCardComponent],
       providers: [
         { provide: DataLayerManagerService, useValue: layerManager },
         { provide: FhirChartLifecycleService, useValue: lifecycleService },
+        { provide: FhirChartConfigurationService, useValue: fhirChartConfigurationService },
       ],
     }).compileComponents();
 

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.ts
@@ -25,7 +25,7 @@ export class FhirChartSummaryComponent {
   @Input() autoAlign = false;
 
   ngOnInit() {
-    this.configService.showSummaryRange(1);
+    this.configService.setSummaryRange(1);
   }
 
   scalePositions$ = this.lifecycleService.afterUpdate$.pipe(

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart-summary/fhir-chart-summary/fhir-chart-summary.component.ts
@@ -3,6 +3,7 @@ import { DataLayerManagerService } from '../../data-layer/data-layer-manager.ser
 import { combineLatest, map, shareReplay } from 'rxjs';
 import { FhirChartLifecycleService } from '../../fhir-chart/fhir-chart-lifecycle.service';
 import { mapValues } from 'lodash-es';
+import { FhirChartConfigurationService } from '../../fhir-chart/fhir-chart-configuration.service';
 
 /**
  * See `*ChartSummary` for example usage.
@@ -14,10 +15,18 @@ import { mapValues } from 'lodash-es';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FhirChartSummaryComponent {
-  constructor(public layerManager: DataLayerManagerService, private lifecycleService: FhirChartLifecycleService) {}
+  constructor(
+    public layerManager: DataLayerManagerService,
+    private lifecycleService: FhirChartLifecycleService,
+    private configService: FhirChartConfigurationService
+  ) {}
 
   /** When set to `true`, each card will be vertically aligned with the corresponding chart. */
   @Input() autoAlign = false;
+
+  ngOnInit() {
+    this.configService.showSummaryRange(1);
+  }
 
   scalePositions$ = this.lifecycleService.afterUpdate$.pipe(
     map(([chart]) => mapValues(chart.scales, ({ axis, top, bottom, height }) => ({ axis, top, bottom, height }))),

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.spec.ts
@@ -444,19 +444,18 @@ describe('FhirChartConfigurationService', () => {
       const configService = new FhirChartConfigurationService(layerManager, timeScaleOptions, timeframeAnnotationOptions, ngZone);
       getTestScheduler().schedule(() => configService.setSummaryRange(3), 20);
       expect(configService.summaryRange$).toBeObservable(
-        hot('x-y', {
-          x: { months: 1, min: new Date('2022-12-31T00:00').getTime(), max: new Date('2023-01-31T00:00').getTime() },
-          y: { months: 3, min: new Date('2022-10-31T00:00').getTime(), max: new Date('2023-01-31T00:00').getTime() },
+        hot('--x', {
+          x: { months: 3, min: new Date('2022-10-31T00:00').getTime(), max: new Date('2023-01-31T00:00').getTime() },
         })
       );
     });
 
-    it('should emit chartConfig$ with timeframe annotations when call showSummaryRange', () => {
+    it('should emit chartConfig$ with timeframe annotations', () => {
       jasmine.clock().mockDate(new Date('2023-01-31T00:00'));
       const a: ManagedDataLayer[] = [{ name: 'a', id: 'a', datasets: [], scale: { id: 'a' } }];
       const layerManager: any = { selectedLayers$: hot('a', { a }) };
       const configService = new FhirChartConfigurationService(layerManager, timeScaleOptions, timeframeAnnotationOptions, ngZone);
-      getTestScheduler().schedule(() => configService.showSummaryRange(3), 20);
+      getTestScheduler().schedule(() => configService.setSummaryRange(3), 20);
       expect(configService.chartConfig$).toBeObservable(
         hot('x-y', {
           x: jasmine.anything(),
@@ -484,37 +483,6 @@ describe('FhirChartConfigurationService', () => {
                       scaleID: 'x',
                       label: { content: '6 months ago' },
                       value: new Date('2022-07-31T00:00').getTime(),
-                    },
-                  ],
-                },
-              }),
-            },
-          },
-        })
-      );
-    });
-
-    it('should emit chartConfig$ with todays timeframe annotations', () => {
-      jasmine.clock().mockDate(new Date('2023-01-31T00:00'));
-      const a: ManagedDataLayer[] = [{ name: 'a', id: 'a', datasets: [], scale: { id: 'a' } }];
-      const layerManager: any = { selectedLayers$: hot('a', { a }) };
-      const configService = new FhirChartConfigurationService(layerManager, timeScaleOptions, timeframeAnnotationOptions, ngZone);
-      getTestScheduler().schedule(() => configService.setSummaryRange(3), 20);
-      expect(configService.chartConfig$).toBeObservable(
-        hot('x-y', {
-          x: jasmine.anything(),
-          y: {
-            ...emptyConfig,
-            options: {
-              ...emptyConfig.options,
-              plugins: jasmine.objectContaining({
-                annotation: {
-                  annotations: [
-                    {
-                      id: 'today',
-                      scaleID: 'x',
-                      label: { content: 'Today' },
-                      value: new Date('2023-01-31T00:00').getTime(),
                     },
                   ],
                 },

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.spec.ts
@@ -451,12 +451,12 @@ describe('FhirChartConfigurationService', () => {
       );
     });
 
-    it('should emit chartConfig$ with timeframe annotations', () => {
+    it('should emit chartConfig$ with timeframe annotations when call showSummaryRange', () => {
       jasmine.clock().mockDate(new Date('2023-01-31T00:00'));
       const a: ManagedDataLayer[] = [{ name: 'a', id: 'a', datasets: [], scale: { id: 'a' } }];
       const layerManager: any = { selectedLayers$: hot('a', { a }) };
       const configService = new FhirChartConfigurationService(layerManager, timeScaleOptions, timeframeAnnotationOptions, ngZone);
-      getTestScheduler().schedule(() => configService.setSummaryRange(3), 20);
+      getTestScheduler().schedule(() => configService.showSummaryRange(3), 20);
       expect(configService.chartConfig$).toBeObservable(
         hot('x-y', {
           x: jasmine.anything(),
@@ -484,6 +484,37 @@ describe('FhirChartConfigurationService', () => {
                       scaleID: 'x',
                       label: { content: '6 months ago' },
                       value: new Date('2022-07-31T00:00').getTime(),
+                    },
+                  ],
+                },
+              }),
+            },
+          },
+        })
+      );
+    });
+
+    it('should emit chartConfig$ with todays timeframe annotations', () => {
+      jasmine.clock().mockDate(new Date('2023-01-31T00:00'));
+      const a: ManagedDataLayer[] = [{ name: 'a', id: 'a', datasets: [], scale: { id: 'a' } }];
+      const layerManager: any = { selectedLayers$: hot('a', { a }) };
+      const configService = new FhirChartConfigurationService(layerManager, timeScaleOptions, timeframeAnnotationOptions, ngZone);
+      getTestScheduler().schedule(() => configService.setSummaryRange(3), 20);
+      expect(configService.chartConfig$).toBeObservable(
+        hot('x-y', {
+          x: jasmine.anything(),
+          y: {
+            ...emptyConfig,
+            options: {
+              ...emptyConfig.options,
+              plugins: jasmine.objectContaining({
+                annotation: {
+                  annotations: [
+                    {
+                      id: 'today',
+                      scaleID: 'x',
+                      label: { content: 'Today' },
+                      value: new Date('2023-01-31T00:00').getTime(),
                     },
                   ],
                 },

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.ts
@@ -29,7 +29,7 @@ export class FhirChartConfigurationService {
     @Inject(TIMEFRAME_ANNOTATION_OPTIONS) private timeframeAnnotationOptions: ChartAnnotation,
     private ngZone: NgZone
   ) {
-    this.setSummaryRange(1);
+    this.setSummaryRange(0);
   }
 
   private timeline: ScaleOptions<'time'> = {
@@ -70,26 +70,19 @@ export class FhirChartConfigurationService {
     }
   }
 
-  showSummaryRange(months: number) {
+  setSummaryRange(months: number) {
     this.annotationSubject.next([
       this.buildTimeframeAnnotation('today', 0),
       this.buildTimeframeAnnotation('current', months),
       this.buildTimeframeAnnotation('previous', months * 2),
     ]);
-    this.summaryRangeSubject.next({
-      months,
-      max: new Date().getTime(),
-      min: subtractMonths(new Date(), months).getTime(),
-    });
-  }
-
-  setSummaryRange(months: number) {
-    this.annotationSubject.next([this.buildTimeframeAnnotation('today', 0)]);
-    this.summaryRangeSubject.next({
-      months,
-      max: new Date().getTime(),
-      min: subtractMonths(new Date(), months).getTime(),
-    });
+    if (months >= 1) {
+      this.summaryRangeSubject.next({
+        months,
+        max: new Date().getTime(),
+        min: subtractMonths(new Date(), months).getTime(),
+      });
+    }
   }
 
   private buildTimeframeAnnotation(id: string, months: number) {

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.ts
@@ -70,12 +70,21 @@ export class FhirChartConfigurationService {
     }
   }
 
-  setSummaryRange(months: number) {
+  showSummaryRange(months: number) {
     this.annotationSubject.next([
       this.buildTimeframeAnnotation('today', 0),
       this.buildTimeframeAnnotation('current', months),
       this.buildTimeframeAnnotation('previous', months * 2),
     ]);
+    this.summaryRangeSubject.next({
+      months,
+      max: new Date().getTime(),
+      min: subtractMonths(new Date(), months).getTime(),
+    });
+  }
+
+  setSummaryRange(months: number) {
+    this.annotationSubject.next([this.buildTimeframeAnnotation('today', 0)]);
     this.summaryRangeSubject.next({
       months,
       max: new Date().getTime(),

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.ts
@@ -71,17 +71,19 @@ export class FhirChartConfigurationService {
   }
 
   setSummaryRange(months: number) {
-    this.annotationSubject.next([
-      this.buildTimeframeAnnotation('today', 0),
-      this.buildTimeframeAnnotation('current', months),
-      this.buildTimeframeAnnotation('previous', months * 2),
-    ]);
-    if (months >= 1) {
+    if (months > 0) {
+      this.annotationSubject.next([
+        this.buildTimeframeAnnotation('today', 0),
+        this.buildTimeframeAnnotation('current', months),
+        this.buildTimeframeAnnotation('previous', months * 2),
+      ]);
       this.summaryRangeSubject.next({
         months,
         max: new Date().getTime(),
         min: subtractMonths(new Date(), months).getTime(),
       });
+    } else {
+      this.annotationSubject.next([this.buildTimeframeAnnotation('today', 0)]);
     }
   }
 


### PR DESCRIPTION
## Overview
 *  The chart should not show vertical lines for “1 month ago” and “2 months ago” by default when there is no summary component.

* The summary component should be responsible for adding these annotations.


## How it was tested
 * Tested locally by running showcase, cardio-patient, and cardio-health app
 * Run unit test cases



## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [x] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
