### PR TITLE
Responsive range selector

### DIFF
--- a/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.css
+++ b/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.css
@@ -1,18 +1,67 @@
+:host {
+  width: 100%;
+}
 .range-selector {
+  display: flex;
+  flex-direction: column;
+  container-type: inline-size;
+}
+.range-selector-controls {
   display: flex;
   align-items: flex-end;
   gap: 8px;
   flex-wrap: wrap;
 }
+@container (width > 532px) {
+  #range-selector-dropdown {
+    display: none;
+  }
+  #range-selector-inline {
+    display: block;
+  }
+}
 
-.range-selector mat-button-toggle-group {
+@container (width <= 532px) {
+  #range-selector-dropdown {
+    display: block;
+  }
+  #range-selector-inline {
+    display: none;
+  }
+}
+@container (width > 300px) {
+  #toggle-buttons {
+    display: flex;
+  }
+  #menu-buttons {
+    display: none;
+  }
+}
+@container (width <= 300px) {
+  #toggle-buttons {
+    display: none;
+  }
+  #menu-buttons {
+    display: block;
+  }
+}
+
+#toggle-buttons,
+#menu-buttons {
   margin-top: 2px;
 }
-.range-selector .toggle-buttons {
-  display: flex;
-  flex-direction: column;
+.button-menu-trigger {
+  height: 50px;
+  --mdc-typography-button-font-weight: 400;
+}
+.dropdown-arrow {
+  vertical-align: bottom;
 }
 
 mat-form-field {
-  max-width: 160px;
+  max-width: 250px;
+}
+.date-range-overlay .date-range,
+.date-range-overlay .calendar {
+  width: 250px;
 }

--- a/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.css
+++ b/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.css
@@ -65,3 +65,8 @@ mat-form-field {
 .date-range-overlay .calendar {
   width: 250px;
 }
+.date-range-dropdown-actions {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0 8px;
+}

--- a/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.css
+++ b/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.css
@@ -29,7 +29,7 @@
     display: none;
   }
 }
-@container (width > 300px) {
+@container (width > 328px) {
   #toggle-buttons {
     display: flex;
   }
@@ -37,7 +37,7 @@
     display: none;
   }
 }
-@container (width <= 300px) {
+@container (width <= 328px) {
   #toggle-buttons {
     display: none;
   }

--- a/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.html
+++ b/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.html
@@ -43,11 +43,17 @@
           <mat-form-field class="date-range" subscriptSizing="dynamic">
             <mat-label>Date Range</mat-label>
             <mat-date-range-input>
-              <input matStartDate placeholder="Start date" [value]="calendarDateRange.start" (dateChange)="dateChange($event, 'min')" #overlayStartDate />
-              <input matEndDate placeholder="End date" [value]="calendarDateRange.end" (dateChange)="dateChange($event, 'max')" />
+              <input
+                matStartDate
+                placeholder="Start date"
+                [value]="calendarDateRange.start"
+                (dateChange)="calendarDateChange($event, 'min')"
+                #overlayStartDate
+              />
+              <input matEndDate placeholder="End date" [value]="calendarDateRange.end" (dateChange)="calendarDateChange($event, 'max')" />
             </mat-date-range-input>
           </mat-form-field>
-          <mat-calendar class="calendar" [selected]="calendarDateRange" (selectedChange)="calendarChange($event)" startView="month"></mat-calendar>
+          <mat-calendar class="calendar" [selected]="calendarDateRange" (selectedChange)="calendarSelectedChange($event)" startView="month"></mat-calendar>
           <div class="date-range-dropdown-actions">
             <button mat-button (click)="dateRangeMenuTrigger.closeMenu()">Cancel</button>
             <button mat-raised-button color="primary" (click)="applyCalendarDateRange(); dateRangeMenuTrigger.closeMenu()">Apply</button>

--- a/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.html
+++ b/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.html
@@ -42,7 +42,11 @@
               <input matEndDate placeholder="End date" [value]="selectedDateRange.end" (dateChange)="dateChange($event, 'max')" />
             </mat-date-range-input>
           </mat-form-field>
-          <mat-calendar class="calendar" #calendar [selected]="selectedDateRange" (selectedChange)="calendarChange($event)" startView="month"> </mat-calendar>
+          <mat-calendar class="calendar" [selected]="selectedDateRange" (selectedChange)="calendarChange($event)" startView="month"></mat-calendar>
+          <div class="date-range-dropdown-actions">
+            <button mat-button>Cancel</button>
+            <button mat-raised-button color="primary">Apply</button>
+          </div>
         </div>
       </mat-menu>
     </div>
@@ -54,7 +58,12 @@
           <input matEndDate placeholder="End date" [value]="selectedDateRange.end" (dateChange)="dateChange($event, 'max')" />
         </mat-date-range-input>
         <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
-        <mat-date-range-picker #picker (closed)="zoomChart()"> </mat-date-range-picker>
+        <mat-date-range-picker #picker (closed)="zoomChart()">
+          <mat-date-range-picker-actions>
+            <button mat-button matDateRangePickerCancel>Cancel</button>
+            <button mat-raised-button color="primary" matDateRangePickerApply>Apply</button>
+          </mat-date-range-picker-actions>
+        </mat-date-range-picker>
       </mat-form-field>
     </div>
   </div>

--- a/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.html
+++ b/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.html
@@ -28,7 +28,12 @@
       </mat-menu>
     </div>
     <div id="range-selector-dropdown">
-      <button mat-icon-button [matMenuTriggerFor]="dateRangeMenu" (menuOpened)="overlayStartDate.focus()" (menuClosed)="zoomChart()">
+      <button
+        mat-icon-button
+        [matMenuTriggerFor]="dateRangeMenu"
+        #dateRangeMenuTrigger="matMenuTrigger"
+        (menuOpened)="openCalendar(); overlayStartDate.focus()"
+      >
         <svg viewBox="0 0 24 24" width="24px" height="24px" focusable="false">
           <path d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V8h14v11zM7 10h5v5H7z"></path>
         </svg>
@@ -38,14 +43,14 @@
           <mat-form-field class="date-range" subscriptSizing="dynamic">
             <mat-label>Date Range</mat-label>
             <mat-date-range-input>
-              <input matStartDate placeholder="Start date" [value]="selectedDateRange.start" (dateChange)="dateChange($event, 'min')" #overlayStartDate />
-              <input matEndDate placeholder="End date" [value]="selectedDateRange.end" (dateChange)="dateChange($event, 'max')" />
+              <input matStartDate placeholder="Start date" [value]="calendarDateRange.start" (dateChange)="dateChange($event, 'min')" #overlayStartDate />
+              <input matEndDate placeholder="End date" [value]="calendarDateRange.end" (dateChange)="dateChange($event, 'max')" />
             </mat-date-range-input>
           </mat-form-field>
-          <mat-calendar class="calendar" [selected]="selectedDateRange" (selectedChange)="calendarChange($event)" startView="month"></mat-calendar>
+          <mat-calendar class="calendar" [selected]="calendarDateRange" (selectedChange)="calendarChange($event)" startView="month"></mat-calendar>
           <div class="date-range-dropdown-actions">
-            <button mat-button>Cancel</button>
-            <button mat-raised-button color="primary">Apply</button>
+            <button mat-button (click)="dateRangeMenuTrigger.closeMenu()">Cancel</button>
+            <button mat-raised-button color="primary" (click)="applyCalendarDateRange(); dateRangeMenuTrigger.closeMenu()">Apply</button>
           </div>
         </div>
       </mat-menu>

--- a/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.html
+++ b/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.html
@@ -1,27 +1,61 @@
-<div class="range-selector" *ngIf="maxDate">
-  <div class="toggle-buttons">
-    <mat-label *ngIf="showTimelineViewTitle">Timeline view</mat-label>
-    <mat-button-toggle-group id="rangeselector" name="fontStyle" aria-label="Font Style" [value]="selectedButton">
-      <mat-button-toggle
-        *ngFor="let rangeButton of rangeSelectorButtons"
-        [id]="rangeButton.value"
-        [value]="rangeButton.month"
-        (click)="updateRangeSelector(rangeButton.month)"
-        >{{ rangeButton.value }}</mat-button-toggle
-      >
-      <mat-button-toggle id="resetzoom" value="All" (click)="resetZoomChart()">All</mat-button-toggle>
-    </mat-button-toggle-group>
+<div class="range-selector" *ngIf="selectedDateRange.start">
+  <mat-label *ngIf="showTimelineViewTitle">Timeline view</mat-label>
+  <div class="range-selector-controls">
+    <div id="toggle-buttons">
+      <mat-button-toggle-group id="rangeselector" name="fontStyle" aria-label="Font Style" [value]="selectedButton">
+        <mat-button-toggle
+          *ngFor="let rangeButton of rangeSelectorButtons"
+          [id]="rangeButton.value"
+          [value]="rangeButton.month"
+          (click)="updateRangeSelector(rangeButton.month)"
+          >{{ rangeButton.value }}</mat-button-toggle
+        >
+        <mat-button-toggle id="resetzoom" value="All" (click)="resetZoomChart()">All</mat-button-toggle>
+      </mat-button-toggle-group>
+    </div>
+    <div id="menu-buttons">
+      <button mat-stroked-button [matMenuTriggerFor]="buttonsMenu" class="button-menu-trigger">
+        {{ selectedButtonLabel }}
+        <svg viewBox="0 0 24 24" width="24px" height="24px" focusable="false" aria-hidden="true" class="dropdown-arrow">
+          <path d="M7 10l5 5 5-5z"></path>
+        </svg>
+      </button>
+      <mat-menu #buttonsMenu="matMenu">
+        <button mat-menu-item *ngFor="let rangeButton of rangeSelectorButtons" [value]="rangeButton.month" (click)="updateRangeSelector(rangeButton.month)">
+          {{ rangeButton.value }}
+        </button>
+        <button mat-menu-item value="All" (click)="resetZoomChart()">All</button>
+      </mat-menu>
+    </div>
+    <div id="range-selector-dropdown">
+      <button mat-icon-button [matMenuTriggerFor]="dateRangeMenu" (menuOpened)="overlayStartDate.focus()" (menuClosed)="zoomChart()">
+        <svg viewBox="0 0 24 24" width="24px" height="24px" focusable="false">
+          <path d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V8h14v11zM7 10h5v5H7z"></path>
+        </svg>
+      </button>
+      <mat-menu #dateRangeMenu="matMenu">
+        <div (click)="$event.stopPropagation()" (keydown)="$event.stopPropagation()" class="date-range-overlay">
+          <mat-form-field class="date-range" subscriptSizing="dynamic">
+            <mat-label>Date Range</mat-label>
+            <mat-date-range-input>
+              <input matStartDate placeholder="Start date" [value]="selectedDateRange.start" (dateChange)="dateChange($event, 'min')" #overlayStartDate />
+              <input matEndDate placeholder="End date" [value]="selectedDateRange.end" (dateChange)="dateChange($event, 'max')" />
+            </mat-date-range-input>
+          </mat-form-field>
+          <mat-calendar class="calendar" #calendar [selected]="selectedDateRange" (selectedChange)="calendarChange($event)" startView="month"> </mat-calendar>
+        </div>
+      </mat-menu>
+    </div>
+    <div id="range-selector-inline">
+      <mat-form-field class="date-range" subscriptSizing="dynamic">
+        <mat-label>Date Range</mat-label>
+        <mat-date-range-input [rangePicker]="picker">
+          <input matStartDate placeholder="Start date" [value]="selectedDateRange.start" (dateChange)="dateChange($event, 'min')" />
+          <input matEndDate placeholder="End date" [value]="selectedDateRange.end" (dateChange)="dateChange($event, 'max')" />
+        </mat-date-range-input>
+        <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+        <mat-date-range-picker #picker (closed)="zoomChart()"> </mat-date-range-picker>
+      </mat-form-field>
+    </div>
   </div>
-  <mat-form-field subscriptSizing="dynamic">
-    <mat-label>Start date</mat-label>
-    <input matInput [matDatepicker]="picker" (dateChange)="dateChange($event, 'min')" [value]="minDate" id="mindate" />
-    <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
-    <mat-datepicker #picker></mat-datepicker>
-  </mat-form-field>
-  <mat-form-field subscriptSizing="dynamic">
-    <mat-label>End date</mat-label>
-    <input matInput [matDatepicker]="pickerDate" (dateChange)="dateChange($event, 'max')" [value]="maxDate" id="maxdate" />
-    <mat-datepicker-toggle matSuffix [for]="pickerDate"></mat-datepicker-toggle>
-    <mat-datepicker #pickerDate></mat-datepicker>
-  </mat-form-field>
 </div>

--- a/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.spec.ts
@@ -18,6 +18,7 @@ import { MatMenuModule } from '@angular/material/menu';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatCalendarHarness, MatDateRangeInputHarness } from '@angular/material/datepicker/testing';
 import { MatMenuHarness } from '@angular/material/menu/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
 
 const max = new Date('2022-03-30T00:00').getTime();
 const min = new Date('2022-01-06T00:00').getTime();
@@ -140,31 +141,31 @@ describe('TimelineRangeSelectorComponent', () => {
     expect(mockConfigService.zoom).toHaveBeenCalledWith({ min, max: new Date('3/2/2023').getTime() });
   });
 
-  it('should call configService.zoom when start date is changed from dropdown', async () => {
-    const menu = await loader.getHarness(MatMenuHarness);
+  it('should call configService.zoom when date range is entered manually in dropdown', async () => {
+    const menu = await loader.getHarness(MatMenuHarness.with({ selector: '#range-selector-dropdown .mat-mdc-menu-trigger' }));
     await menu.open();
     const rangeInput = await menu.getHarness(MatDateRangeInputHarness);
     const startInput = await rangeInput.getStartInput();
     await startInput.setValue('3/2/2020');
-    expect(mockConfigService.zoom).toHaveBeenCalledWith({ min: new Date('3/2/2020').getTime(), max });
-  });
-
-  it('should call configService.zoom when end date is changed from dropdown', async () => {
-    const menu = await loader.getHarness(MatMenuHarness);
-    await menu.open();
-    const rangeInput = await menu.getHarness(MatDateRangeInputHarness);
-    const startInput = await rangeInput.getEndInput();
-    await startInput.setValue('3/2/2023');
-    expect(mockConfigService.zoom).toHaveBeenCalledWith({ min, max: new Date('3/2/2023').getTime() });
+    const endInput = await rangeInput.getEndInput();
+    await endInput.setValue('3/2/2023');
+    const apply = await menu.getHarness(MatButtonHarness.with({ text: 'Apply' }));
+    await apply.click();
+    expect(mockConfigService.zoom).toHaveBeenCalledWith({
+      min: new Date('3/2/2020').getTime(),
+      max: new Date('3/2/2023').getTime(),
+    });
   });
 
   it('should call configService.zoom when range is selected on calendar', async () => {
-    const menu = await loader.getHarness(MatMenuHarness);
+    const menu = await loader.getHarness(MatMenuHarness.with({ selector: '#range-selector-dropdown .mat-mdc-menu-trigger' }));
     await menu.open();
     const calendar = await menu.getHarness(MatCalendarHarness);
     const monthYear = await calendar.getCurrentViewLabel();
     await calendar.selectCell({ text: '1' });
     await calendar.selectCell({ text: '22' });
+    const apply = await menu.getHarness(MatButtonHarness.with({ text: 'Apply' }));
+    await apply.click();
     expect(mockConfigService.zoom).toHaveBeenCalledWith({
       min: new Date(`1 ${monthYear}`).getTime(),
       max: new Date(`22 ${monthYear}`).getTime(),

--- a/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatInputModule } from '@angular/material/input';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { By } from '@angular/platform-browser';
 import { MatButtonToggleHarness } from '@angular/material/button-toggle/testing';
 import { of } from 'rxjs';
@@ -11,10 +10,14 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatNativeDateModule } from '@angular/material/core';
-import { FormsModule } from '@angular/forms';
 import { FhirChartConfigurationService } from '../fhir-chart/fhir-chart-configuration.service';
 import { SummaryRangeSelectorComponent } from '../summary-range-selector/summary-range-selector.component';
 import { SummaryService } from '../fhir-chart-summary/summary.service';
+import { MatButtonModule } from '@angular/material/button';
+import { MatMenuModule } from '@angular/material/menu';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatCalendarHarness, MatDateRangeInputHarness } from '@angular/material/datepicker/testing';
+import { MatMenuHarness } from '@angular/material/menu/testing';
 
 const max = new Date('2022-03-30T00:00').getTime();
 const min = new Date('2022-01-06T00:00').getTime();
@@ -35,7 +38,7 @@ describe('TimelineRangeSelectorComponent', () => {
   beforeEach(async () => {
     mockConfigService = new MockConfigService();
     await TestBed.configureTestingModule({
-      imports: [MatButtonToggleModule, MatInputModule, FormsModule, BrowserAnimationsModule, MatDatepickerModule, MatNativeDateModule],
+      imports: [NoopAnimationsModule, MatInputModule, MatDatepickerModule, MatNativeDateModule, MatButtonModule, MatButtonToggleModule, MatMenuModule],
       declarations: [TimelineRangeSelectorComponent, SummaryRangeSelectorComponent],
       providers: [{ provide: FhirChartConfigurationService, useValue: mockConfigService }, SummaryService],
     }).compileComponents();
@@ -63,7 +66,7 @@ describe('TimelineRangeSelectorComponent', () => {
     let ButtonInputGroup = await loader.getHarness(MatButtonToggleHarness.with({ selector: "[id='1 mo']" }));
     await ButtonInputGroup.check();
     const expectedMinDate = new Date('2022-02-28T00:00');
-    expect(component.minDate).toEqual(expectedMinDate);
+    expect(component.selectedDateRange.start).toEqual(expectedMinDate);
   });
 
   it('should calculate proper 3 month ago date from max layer date', async () => {
@@ -71,7 +74,7 @@ describe('TimelineRangeSelectorComponent', () => {
     let ButtonInput = await loader.getHarness(MatButtonToggleHarness.with({ selector: "[id='3 mo']" }));
     await ButtonInput.check();
     const expectedMinDate = new Date('2021-12-30T00:00');
-    expect(component.minDate).toEqual(expectedMinDate);
+    expect(component.selectedDateRange.start).toEqual(expectedMinDate);
   });
 
   it('should calculate proper 6 month ago date from max layer date', async () => {
@@ -79,7 +82,7 @@ describe('TimelineRangeSelectorComponent', () => {
     let ButtonInput = await loader.getHarness(MatButtonToggleHarness.with({ selector: "[id='6 mo']" }));
     await ButtonInput.check();
     const expectedMinDate = new Date('2021-09-30T00:00');
-    expect(component.minDate).toEqual(expectedMinDate);
+    expect(component.selectedDateRange.start).toEqual(expectedMinDate);
   });
 
   it('should calculate proper 12 month ago date from max layer date', async () => {
@@ -87,7 +90,7 @@ describe('TimelineRangeSelectorComponent', () => {
     let ButtonInput = await loader.getHarness(MatButtonToggleHarness.with({ selector: "[id='1 y']" }));
     await ButtonInput.check();
     const expectedMinDate = new Date('2021-03-30T00:00');
-    expect(component.minDate).toEqual(expectedMinDate);
+    expect(component.selectedDateRange.start).toEqual(expectedMinDate);
   });
 
   it('should reset a chart when click on all button', async () => {
@@ -100,14 +103,14 @@ describe('TimelineRangeSelectorComponent', () => {
     const date: any = { value: new Date(2020, 2, 2) };
     component.dateChange(date, 'min');
     fixture.detectChanges();
-    expect(component.minDate).toEqual(date.value);
+    expect(component.selectedDateRange.start).toEqual(date.value);
   });
 
   it('should check dateChange selected event for end date', () => {
     const date: any = { value: new Date(2020, 2, 2) };
     component.dateChange(date, 'max');
     fixture.detectChanges();
-    expect(component.maxDate).toEqual(date.value);
+    expect(component.selectedDateRange.end).toEqual(date.value);
   });
 
   it('should check month difference between two dates', async () => {
@@ -117,9 +120,54 @@ describe('TimelineRangeSelectorComponent', () => {
     expect(months).toEqual(1);
   });
 
-  it('should subscribe timelineRange when the component initializes and set minDate and maxDate', async () => {
-    expect(component.minDate).toEqual(new Date(min));
-    expect(component.maxDate).toEqual(new Date(max));
+  it('should subscribe timelineRange when the component initializes and set selectedDateRange', async () => {
+    expect(component.selectedDateRange.start).toEqual(new Date(min));
+    expect(component.selectedDateRange.end).toEqual(new Date(max));
     expect(component.selectedButton).toEqual(2);
+  });
+
+  it('should call configService.zoom when start date is changed', async () => {
+    let rangeInput = await loader.getHarness(MatDateRangeInputHarness);
+    let startInput = await rangeInput.getStartInput();
+    await startInput.setValue('3/2/2020');
+    expect(mockConfigService.zoom).toHaveBeenCalledWith({ min: new Date('3/2/2020').getTime(), max });
+  });
+
+  it('should call configService.zoom when end date is changed', async () => {
+    let rangeInput = await loader.getHarness(MatDateRangeInputHarness);
+    let endInput = await rangeInput.getEndInput();
+    await endInput.setValue('3/2/2023');
+    expect(mockConfigService.zoom).toHaveBeenCalledWith({ min, max: new Date('3/2/2023').getTime() });
+  });
+
+  it('should call configService.zoom when start date is changed from dropdown', async () => {
+    const menu = await loader.getHarness(MatMenuHarness);
+    await menu.open();
+    const rangeInput = await menu.getHarness(MatDateRangeInputHarness);
+    const startInput = await rangeInput.getStartInput();
+    await startInput.setValue('3/2/2020');
+    expect(mockConfigService.zoom).toHaveBeenCalledWith({ min: new Date('3/2/2020').getTime(), max });
+  });
+
+  it('should call configService.zoom when end date is changed from dropdown', async () => {
+    const menu = await loader.getHarness(MatMenuHarness);
+    await menu.open();
+    const rangeInput = await menu.getHarness(MatDateRangeInputHarness);
+    const startInput = await rangeInput.getEndInput();
+    await startInput.setValue('3/2/2023');
+    expect(mockConfigService.zoom).toHaveBeenCalledWith({ min, max: new Date('3/2/2023').getTime() });
+  });
+
+  it('should call configService.zoom when range is selected on calendar', async () => {
+    const menu = await loader.getHarness(MatMenuHarness);
+    await menu.open();
+    const calendar = await menu.getHarness(MatCalendarHarness);
+    const monthYear = await calendar.getCurrentViewLabel();
+    await calendar.selectCell({ text: '1' });
+    await calendar.selectCell({ text: '22' });
+    expect(mockConfigService.zoom).toHaveBeenCalledWith({
+      min: new Date(`1 ${monthYear}`).getTime(),
+      max: new Date(`22 ${monthYear}`).getTime(),
+    });
   });
 });

--- a/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectorRef, Component, Input } from '@angular/core';
-import { MatDatepickerInputEvent } from '@angular/material/datepicker';
+import { DateRange, MatDatepickerInputEvent } from '@angular/material/datepicker';
 import { delay } from 'rxjs';
 import { FhirChartConfigurationService } from '../fhir-chart/fhir-chart-configuration.service';
 import { subtractMonths } from '../utils';
@@ -13,8 +13,7 @@ import { subtractMonths } from '../utils';
   styleUrls: ['./timeline-range-selector.component.css'],
 })
 export class TimelineRangeSelectorComponent {
-  maxDate?: Date;
-  minDate?: Date;
+  selectedDateRange: DateRange<Date> = new DateRange<Date>(null, null);
   rangeSelectorButtons = [
     { month: 1, value: '1 mo' },
     { month: 3, value: '3 mo' },
@@ -22,53 +21,67 @@ export class TimelineRangeSelectorComponent {
     { month: 12, value: '1 y' },
   ];
   selectedButton: number | 'All' = 'All';
+  get selectedButtonLabel(): string {
+    if (this.selectedButton === 'All') {
+      return 'All';
+    }
+    const button = this.rangeSelectorButtons.find((b) => b.month === this.selectedButton);
+    return button ? button.value : 'Custom';
+  }
   @Input() showTimelineViewTitle: boolean = false;
 
   constructor(private changeDetectorRef: ChangeDetectorRef, private configService: FhirChartConfigurationService) {}
 
   ngOnInit(): void {
     this.configService.timelineRange$.pipe(delay(0)).subscribe((timelineRange) => {
-      this.maxDate = new Date(timelineRange.max);
-      this.minDate = new Date(timelineRange.min);
-      if (this.configService.isAutoZoom) {
+      this.selectedDateRange = new DateRange(new Date(timelineRange.min), new Date(timelineRange.max));
+      if (this.configService.isAutoZoom || !this.selectedDateRange.start || !this.selectedDateRange.end) {
         this.selectedButton = 'All';
       } else {
-        this.selectedButton = this.calculateMonthDiff(this.minDate, this.maxDate);
+        this.selectedButton = this.calculateMonthDiff(this.selectedDateRange.start, this.selectedDateRange.end);
       }
       this.changeDetectorRef.markForCheck();
     });
   }
 
   updateRangeSelector(monthCount: number) {
-    if (this.maxDate && monthCount) {
-      this.maxDate = new Date();
-      this.minDate = subtractMonths(this.maxDate, monthCount);
-      this.configService.zoom({
-        min: this.minDate.getTime(),
-        max: new Date().getTime(),
-      });
+    if (this.selectedDateRange.end && monthCount) {
+      const maxDate = new Date();
+      this.selectedDateRange = new DateRange(subtractMonths(maxDate, monthCount), maxDate);
+      this.zoomChart();
     }
   }
 
+  zoomChart() {
+    if (this.selectedDateRange.start && this.selectedDateRange.end) {
+      this.configService.zoom({
+        min: this.selectedDateRange.start.getTime(),
+        max: this.selectedDateRange.end.getTime(),
+      });
+    }
+  }
   resetZoomChart() {
     this.configService.resetZoom();
   }
 
   dateChange(event: MatDatepickerInputEvent<Date>, datePickerType: string) {
-    if (event.value) {
-      if (datePickerType === 'min') {
-        this.minDate = event.value;
-      } else {
-        this.maxDate = event.value;
-      }
-      if (this.minDate && this.maxDate) {
-        this.configService.zoom({
-          min: this.minDate.getTime(),
-          max: this.maxDate.getTime(),
-        });
-      }
+    console.log('dateChange', event, datePickerType);
+    if (datePickerType === 'min') {
+      this.selectedDateRange = new DateRange(event.value, this.selectedDateRange.end);
+    } else {
+      this.selectedDateRange = new DateRange(this.selectedDateRange.start, event.value);
     }
+    // this.zoomChart();
   }
+  calendarChange(date: Date): void {
+    if (this.selectedDateRange.start && date > this.selectedDateRange.start && !this.selectedDateRange.end) {
+      this.selectedDateRange = new DateRange(this.selectedDateRange.start, date);
+    } else {
+      this.selectedDateRange = new DateRange(date, null);
+    }
+    // this.zoomChart();
+  }
+
   calculateMonthDiff(minDateValue: Date, maxDateValue: Date): number {
     let months = (maxDateValue.getFullYear() - minDateValue.getFullYear()) * 12;
     months -= minDateValue.getMonth();

--- a/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.ts
@@ -3,6 +3,7 @@ import { DateRange, MatDatepickerInputEvent } from '@angular/material/datepicker
 import { delay } from 'rxjs';
 import { FhirChartConfigurationService } from '../fhir-chart/fhir-chart-configuration.service';
 import { subtractMonths } from '../utils';
+import { zoom } from 'chartjs-plugin-zoom';
 
 /**
  * See `*TimelineRangeSelector` for example usage.
@@ -71,13 +72,22 @@ export class TimelineRangeSelectorComponent {
     } else {
       this.selectedDateRange = new DateRange(this.selectedDateRange.start, event.value);
     }
+    this.zoomChart();
   }
 
   openCalendar() {
     this.calendarDateRange = this.selectedDateRange;
   }
 
-  calendarChange(date: Date): void {
+  calendarDateChange(event: MatDatepickerInputEvent<Date>, datePickerType: string) {
+    if (datePickerType === 'min') {
+      this.calendarDateRange = new DateRange(event.value, this.calendarDateRange.end);
+    } else {
+      this.calendarDateRange = new DateRange(this.calendarDateRange.start, event.value);
+    }
+  }
+
+  calendarSelectedChange(date: Date): void {
     if (this.calendarDateRange.start && date > this.calendarDateRange.start && !this.calendarDateRange.end) {
       this.calendarDateRange = new DateRange(this.calendarDateRange.start, date);
     } else {

--- a/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.ts
@@ -3,7 +3,6 @@ import { DateRange, MatDatepickerInputEvent } from '@angular/material/datepicker
 import { delay } from 'rxjs';
 import { FhirChartConfigurationService } from '../fhir-chart/fhir-chart-configuration.service';
 import { subtractMonths } from '../utils';
-import { zoom } from 'chartjs-plugin-zoom';
 
 /**
  * See `*TimelineRangeSelector` for example usage.

--- a/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.ts
@@ -14,6 +14,7 @@ import { subtractMonths } from '../utils';
 })
 export class TimelineRangeSelectorComponent {
   selectedDateRange: DateRange<Date> = new DateRange<Date>(null, null);
+  calendarDateRange: DateRange<Date> = new DateRange<Date>(null, null);
   rangeSelectorButtons = [
     { month: 1, value: '1 mo' },
     { month: 3, value: '3 mo' },
@@ -71,12 +72,22 @@ export class TimelineRangeSelectorComponent {
       this.selectedDateRange = new DateRange(this.selectedDateRange.start, event.value);
     }
   }
+
+  openCalendar() {
+    this.calendarDateRange = this.selectedDateRange;
+  }
+
   calendarChange(date: Date): void {
-    if (this.selectedDateRange.start && date > this.selectedDateRange.start && !this.selectedDateRange.end) {
-      this.selectedDateRange = new DateRange(this.selectedDateRange.start, date);
+    if (this.calendarDateRange.start && date > this.calendarDateRange.start && !this.calendarDateRange.end) {
+      this.calendarDateRange = new DateRange(this.calendarDateRange.start, date);
     } else {
-      this.selectedDateRange = new DateRange(date, null);
+      this.calendarDateRange = new DateRange(date, null);
     }
+  }
+
+  applyCalendarDateRange() {
+    this.selectedDateRange = this.calendarDateRange;
+    this.zoomChart();
   }
 
   calculateMonthDiff(minDateValue: Date, maxDateValue: Date): number {

--- a/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.ts
@@ -65,13 +65,11 @@ export class TimelineRangeSelectorComponent {
   }
 
   dateChange(event: MatDatepickerInputEvent<Date>, datePickerType: string) {
-    console.log('dateChange', event, datePickerType);
     if (datePickerType === 'min') {
       this.selectedDateRange = new DateRange(event.value, this.selectedDateRange.end);
     } else {
       this.selectedDateRange = new DateRange(this.selectedDateRange.start, event.value);
     }
-    // this.zoomChart();
   }
   calendarChange(date: Date): void {
     if (this.selectedDateRange.start && date > this.selectedDateRange.start && !this.selectedDateRange.end) {
@@ -79,7 +77,6 @@ export class TimelineRangeSelectorComponent {
     } else {
       this.selectedDateRange = new DateRange(date, null);
     }
-    // this.zoomChart();
   }
 
   calculateMonthDiff(minDateValue: Date, maxDateValue: Date): number {

--- a/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.module.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TimelineRangeSelectorComponent } from './timeline-range-selector.component';
-import { DefaultMatCalendarRangeStrategy, MAT_DATE_RANGE_SELECTION_STRATEGY, MatDatepickerModule } from '@angular/material/datepicker';
+import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatNativeDateModule } from '@angular/material/core';
@@ -12,11 +12,5 @@ import { MatMenuModule } from '@angular/material/menu';
   declarations: [TimelineRangeSelectorComponent],
   imports: [CommonModule, MatInputModule, MatDatepickerModule, MatNativeDateModule, MatButtonModule, MatButtonToggleModule, MatMenuModule],
   exports: [TimelineRangeSelectorComponent],
-  // providers: [
-  //   {
-  //     provide: MAT_DATE_RANGE_SELECTION_STRATEGY,
-  //     useClass: DefaultMatCalendarRangeStrategy,
-  //   },
-  // ],
 })
 export class TimelineRangeSelectorModule {}

--- a/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.module.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.module.ts
@@ -1,15 +1,22 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TimelineRangeSelectorComponent } from './timeline-range-selector.component';
-import { MatDatepickerModule } from '@angular/material/datepicker';
+import { DefaultMatCalendarRangeStrategy, MAT_DATE_RANGE_SELECTION_STRATEGY, MatDatepickerModule } from '@angular/material/datepicker';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatNativeDateModule } from '@angular/material/core';
-import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatMenuModule } from '@angular/material/menu';
 
 @NgModule({
   declarations: [TimelineRangeSelectorComponent],
-  imports: [CommonModule, MatDatepickerModule, MatInputModule, MatButtonToggleModule, MatNativeDateModule, FormsModule],
+  imports: [CommonModule, MatInputModule, MatDatepickerModule, MatNativeDateModule, MatButtonModule, MatButtonToggleModule, MatMenuModule],
   exports: [TimelineRangeSelectorComponent],
+  // providers: [
+  //   {
+  //     provide: MAT_DATE_RANGE_SELECTION_STRATEGY,
+  //     useClass: DefaultMatCalendarRangeStrategy,
+  //   },
+  // ],
 })
 export class TimelineRangeSelectorModule {}


### PR DESCRIPTION
## Overview

- Use Material range selector instead of two date selectors
- Added alternate date range selector in dropdown menu
- Added alternate toggle buttons in dropdown menu
- Use CSS container queries to switch between alternative controls

## How it was tested

- Ran cardio, showcase, and documentation apps
- Tested responsiveness when resized browser window, expanded sidebar
- Tested entering dates manually and via calendar in both alternatives
- Tested that graph updates correctly in all cases
- Tested switching between range presets with button toggles and dropdown menu

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [x] I have included screen shots for changes that affect the user interface
- [x] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
