### PR TITLE
Rt 895 graph shows endless loading animation after request error

### DIFF
--- a/libs/ngx-charts-on-fhir/package.json
+++ b/libs/ngx-charts-on-fhir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elimuinformatics/ngx-charts-on-fhir",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Charts-on-FHIR: A data visualization library for SMART-on-FHIR healthcare applications",
   "license": "Apache-2.0",
   "homepage": "https://elimuinformatics.github.io/charts-on-fhir",

--- a/libs/ngx-charts-on-fhir/package.json
+++ b/libs/ngx-charts-on-fhir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elimuinformatics/ngx-charts-on-fhir",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Charts-on-FHIR: A data visualization library for SMART-on-FHIR healthcare applications",
   "license": "Apache-2.0",
   "homepage": "https://elimuinformatics.github.io/charts-on-fhir",

--- a/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-manager.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-manager.service.ts
@@ -143,7 +143,7 @@ export class DataLayerManagerService {
           const layers = this.mergeService.merge(this.state.layers, layer);
           this.state = { ...this.state, layers };
         },
-        error: (err) => console.error(err),
+        error: (err) => this.loading$.next(false),
         complete: () => {
           this.loading$.next(false);
         },

--- a/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-manager.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-manager.service.ts
@@ -143,7 +143,10 @@ export class DataLayerManagerService {
           const layers = this.mergeService.merge(this.state.layers, layer);
           this.state = { ...this.state, layers };
         },
-        error: (err) => this.loading$.next(false),
+        error: (err) => {
+          console.error(err);
+          this.loading$.next(false);
+        },
         complete: () => {
           this.loading$.next(false);
         },


### PR DESCRIPTION
## Overview
 * For error we are disabling a loading. so it will show an error message not to continue loading.


## How it was tested
 * Tested for all charts on fhir app
 * Run a unit test on local.


## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
