### PR TITLE
RT-907-(charts-on-fhir) Empty message does not make sense when user cannot select layers

### DIFF
--- a/apps/showcase/src/app/app.component.html
+++ b/apps/showcase/src/app/app.component.html
@@ -2,7 +2,7 @@
   <div class="layout-main">
     <timeline-range-selector [showTimelineViewTitle]="true" class="layout-main-range"></timeline-range-selector>
     <summary-range-selector class="layout-summary-selector"></summary-range-selector>
-    <fhir-chart class="layout-main-chart" width="100%" height="100%" [floatingContent]="legend"> </fhir-chart>
+    <fhir-chart class="layout-main-chart" width="100%" height="100%" [floatingContent]="legend" [emptyMessage]="'No data layers are selected'"> </fhir-chart>
     <ng-template #legend>
       <fhir-chart-tags-legend></fhir-chart-tags-legend>
     </ng-template>

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.html
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.html
@@ -15,7 +15,7 @@
             <div>Loading data...</div>
             <mat-progress-bar mode="indeterminate"></mat-progress-bar>
           </ng-container>
-          <ng-template #doneLoading>No data layers are selected</ng-template>
+          <ng-template #doneLoading>{{ emptyMessage }}</ng-template>
         </div>
       </div>
     </ng-template>

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.ts
@@ -32,6 +32,8 @@ export class FhirChartComponent implements OnInit {
 
   @Input() floatingContent?: TemplateRef<unknown>;
 
+  @Input() emptyMessage: string = 'No data';
+
   constructor(private configService: FhirChartConfigurationService, public layerManager: DataLayerManagerService) {}
 
   ngOnInit(): void {


### PR DESCRIPTION
## Overview

- Modify the fhir-chart component to accept a customEmptyMessage input of type TemplateRef.
- Update the component's template to use the customEmptyMessage input when provided, otherwise use a default message.
- In the showcase app, set the customEmptyMessage input to "No data layers are selected" using a TemplateRef containing this message.
![image](https://github.com/elimuinformatics/charts-on-fhir/assets/57406228/54e5e3dc-e319-404a-ad31-38127f5107e1)
![image](https://github.com/elimuinformatics/charts-on-fhir/assets/57406228/01313351-6eb0-4a6d-8cb9-23b25ab69472)


## How it was tested

- Tested locally using run all charts-on-fhir apps.


## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [x] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
