### PR TITLE
Customize layer name

### DIFF
--- a/libs/ngx-charts-on-fhir/package.json
+++ b/libs/ngx-charts-on-fhir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elimuinformatics/ngx-charts-on-fhir",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Charts-on-FHIR: A data visualization library for SMART-on-FHIR healthcare applications",
   "license": "Apache-2.0",
   "homepage": "https://elimuinformatics.github.io/charts-on-fhir",

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/blood-pressure-mapper.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/blood-pressure-mapper.service.ts
@@ -40,7 +40,7 @@ export function isBloodPressureObservation(resource: Observation): resource is B
 export class BloodPressureMapper implements Mapper<BloodPressureObservation> {
   constructor(private baseMapper: ComponentObservationMapper) {}
   canMap = isBloodPressureObservation;
-  map(resource: BloodPressureObservation): DataLayer {
+  map(resource: BloodPressureObservation, layerName?: string): DataLayer {
     for (let component of resource.component) {
       if (codeEquals(component.code, systolicCode)) {
         component.referenceRange = [
@@ -59,6 +59,6 @@ export class BloodPressureMapper implements Mapper<BloodPressureObservation> {
         ];
       }
     }
-    return this.baseMapper.map(resource);
+    return this.baseMapper.map(resource, layerName);
   }
 }

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/component-observation-mapper.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/component-observation-mapper.service.spec.ts
@@ -166,5 +166,21 @@ describe('ComponentObservationMapper', () => {
       };
       expect(mapper.map(observation).category).toEqual(['A', 'B']);
     });
+
+    it('should use custom layer name as axis label', () => {
+      const observation: ComponentObservation = {
+        resourceType: 'Observation',
+        status: 'final',
+        code: { text: 'text' },
+        effectiveDateTime: new Date().toISOString(),
+        component: [
+          {
+            code: { text: 'component' },
+            valueQuantity: { value: 7, unit: 'unit' },
+          },
+        ],
+      };
+      expect((mapper.map(observation, 'custom').scale as any).title.text[0]).toBe('custom');
+    });
   });
 });

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/component-observation-mapper.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/component-observation-mapper.service.ts
@@ -52,14 +52,15 @@ export class ComponentObservationMapper implements Mapper<ComponentObservation> 
     private codeService: FhirCodeService
   ) {}
   canMap = isComponentObservation;
-  map(resource: ComponentObservation): DataLayer {
+  map(resource: ComponentObservation, layerName?: string): DataLayer {
     const codeName = this.codeService.getName(resource.code);
+    layerName = layerName ?? codeName;
     return {
-      name: codeName,
+      name: layerName,
       category: resource.category?.flatMap((c) => c.coding?.map((coding) => coding.display)).filter(isDefined),
       datasets: resource.component.map((component) => ({
         label: this.codeService.getName(component.code) + getMeasurementSettingSuffix(resource),
-        yAxisID: codeName,
+        yAxisID: layerName,
         data: [
           {
             x: new Date(resource.effectiveDateTime).getTime(),
@@ -75,8 +76,8 @@ export class ComponentObservationMapper implements Mapper<ComponentObservation> 
         },
       })),
       scale: merge({}, this.linearScaleOptions, {
-        id: codeName,
-        title: { text: [codeName, resource.component[0].valueQuantity.unit] },
+        id: layerName,
+        title: { text: [layerName, resource.component[0].valueQuantity.unit] },
         stackWeight: resource.component.length,
       }),
       annotations: resource.component.flatMap(
@@ -85,7 +86,7 @@ export class ComponentObservationMapper implements Mapper<ComponentObservation> 
             merge({}, this.annotationOptions, {
               id: `${this.codeService.getName(component.code)} Reference Range`,
               label: { content: `${this.codeService.getName(component.code)} Reference Range` },
-              yScaleID: codeName,
+              yScaleID: layerName,
               yMax: range?.high?.value,
               yMin: range?.low?.value,
             })

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/simple-observation-mapper.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/simple-observation-mapper.service.spec.ts
@@ -136,5 +136,16 @@ describe('SimpleObservationMapper', () => {
       };
       expect(mapper.map(observation).datasets[0].label).toBe('text' + HOME_DATASET_LABEL_SUFFIX);
     });
+
+    it('should use custom layer name as axis label', () => {
+      const observation: SimpleObservation = {
+        resourceType: 'Observation',
+        status: 'final',
+        code: { text: 'text' },
+        effectiveDateTime: new Date().toISOString(),
+        valueQuantity: { value: 7, unit: 'unit' },
+      };
+      expect((mapper.map(observation, 'custom').scale as any).title.text[0]).toBe('custom');
+    });
   });
 });

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/simple-observation-mapper.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/simple-observation-mapper.service.ts
@@ -43,15 +43,16 @@ export class SimpleObservationMapper implements Mapper<SimpleObservation> {
     private codeService: FhirCodeService
   ) {}
   canMap = isSimpleObservation;
-  map(resource: SimpleObservation): DataLayer {
+  map(resource: SimpleObservation, layerName?: string): DataLayer {
     const codeName = this.codeService.getName(resource.code);
+    layerName = layerName ?? codeName;
     return {
-      name: codeName,
+      name: layerName,
       category: resource.category?.flatMap((c) => c.coding?.map((coding) => coding.display)).filter(isDefined),
       datasets: [
         {
           label: codeName + getMeasurementSettingSuffix(resource),
-          yAxisID: codeName,
+          yAxisID: layerName,
           data: [
             {
               x: new Date(resource.effectiveDateTime).getTime(),
@@ -60,22 +61,22 @@ export class SimpleObservationMapper implements Mapper<SimpleObservation> {
             },
           ],
           chartsOnFhir: {
-            group: codeName,
+            group: layerName,
             colorPalette: isHomeMeasurement(resource) ? 'light' : 'dark',
             tags: [isHomeMeasurement(resource) ? 'Home' : 'Clinic'],
-            referenceRangeAnnotation: `${codeName} Reference Range`,
+            referenceRangeAnnotation: `${layerName} Reference Range`,
           },
         },
       ],
       scale: merge({}, this.linearScaleOptions, {
-        id: codeName,
-        title: { text: [codeName, resource.valueQuantity.unit] },
+        id: layerName,
+        title: { text: [layerName, resource.valueQuantity.unit] },
       }),
       annotations: resource.referenceRange?.map<ChartAnnotation>((range) =>
         merge({}, this.annotationOptions, {
-          id: `${codeName} Reference Range`,
-          label: { content: `${codeName} Reference Range` },
-          yScaleID: codeName,
+          id: `${layerName} Reference Range`,
+          label: { content: `${layerName} Reference Range` },
+          yScaleID: layerName,
           yMax: range?.high?.value,
           yMin: range?.low?.value,
         })


### PR DESCRIPTION
## Overview

- Adds a layerName parameter to Observation mappers
- This makes it easier for custom mappers to change the layer name and scale label when calling the base mapper.

## How it was tested

- Wrote a custom mapper that uses the layerName parameter (not committed)
- Ran showcase app and verified that custom name shows up in layer list, chart label, and summary card

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [x] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
