### PR TITLE
RT-1116: (charts-on-fhir) medication graph label cut off

### DIFF
--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/medication-request/simple-medication-mapper.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/medication-request/simple-medication-mapper.service.spec.ts
@@ -105,5 +105,40 @@ describe('SimpleMedicationMapper', () => {
         afterDatasetsDraw: jasmine.any(Function),
       });
     });
+
+    it('should register custom plugin and invoke afterDatasetsDraw function', () => {
+      const mockChart: any = {
+        ctx: {
+          fillStyle: 'black',
+          font: '14px Arial',
+          textAlign: 'start',
+          textBaseline: 'middle',
+          fillText: jasmine.createSpy('fillText'),
+        },
+        data: {
+          datasets: [
+            {
+              label: 'TestLabel',
+            },
+          ],
+        },
+        getDatasetMeta: jasmine.createSpy('getDatasetMeta').and.returnValue({
+          yAxisID: 'medications',
+          data: [{ y: 10 }, { y: 20 }],
+        }),
+        chartArea: {
+          left: 50,
+        },
+        afterDatasetsDraw: () => {},
+      };
+
+      spyOn(Chart, 'register').and.callFake((plugin) => {
+        if ((plugin as any).id === 'customLabels') {
+          (plugin as any).afterDatasetsDraw(mockChart);
+        }
+      });
+      mapper.registerCustomPlugin();
+      expect(mockChart.ctx.fillText).toHaveBeenCalledWith('TestLabel', 50, 15);
+    });
   });
 });

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/medication-request/simple-medication-mapper.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/medication-request/simple-medication-mapper.service.spec.ts
@@ -3,6 +3,7 @@ import { SimpleMedication, SimpleMedicationMapper } from './simple-medication-ma
 import { TestBed } from '@angular/core/testing';
 import { FhirCodeService } from '../fhir-code.service';
 import { CATEGORY_SCALE_OPTIONS } from '../fhir-mapper-options';
+import { Chart } from 'chart.js';
 
 describe('SimpleMedicationMapper', () => {
   let mapper: SimpleMedicationMapper;
@@ -91,6 +92,17 @@ describe('SimpleMedicationMapper', () => {
         id: 'medications',
         type: 'category',
         title: { text: ['Prescribed', 'Medications'] },
+      });
+    });
+  });
+
+  describe('registerCustomPlugin', () => {
+    it('should register custom plugin with id "customLabels"', () => {
+      spyOn(Chart, 'register');
+      mapper.registerCustomPlugin();
+      expect(Chart.register).toHaveBeenCalledWith({
+        id: 'customLabels',
+        afterDatasetsDraw: jasmine.any(Function),
       });
     });
   });

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/medication-request/simple-medication-mapper.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/medication-request/simple-medication-mapper.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Inject } from '@angular/core';
-import { ScaleOptions } from 'chart.js';
+import { ScaleOptions, Chart } from 'chart.js';
 import { MedicationRequest } from 'fhir/r4';
 import { merge } from 'lodash-es';
 import { DataLayer, TimelineChartType, TimelineDataPoint } from '../../data-layer/data-layer';
@@ -32,6 +32,7 @@ export class SimpleMedicationMapper implements Mapper<SimpleMedication> {
   constructor(@Inject(CATEGORY_SCALE_OPTIONS) private categoryScaleOptions: ScaleOptions<'category'>, private codeService: FhirCodeService) {}
   canMap = isMedication;
   map(resource: SimpleMedication): DataLayer<TimelineChartType, MedicationDataPoint[]> {
+    this.registerCustomPlugin();
     const authoredOn = new Date(resource.authoredOn).getTime();
     const codeName = this.codeService.getName(resource?.medicationCodeableConcept);
     return {
@@ -65,28 +66,27 @@ export class SimpleMedicationMapper implements Mapper<SimpleMedication> {
         id: 'medications',
         title: { text: ['Prescribed', 'Medications'] },
       }),
-      // use annotations for labels so they are drawn on top of the data (axis labels are drawn underneath)
-      annotations: [
-        {
-          id: codeName,
-          type: 'line',
-          borderWidth: 0,
-          label: {
-            display: true,
-            content: [codeName],
-            position: 'start',
-            color: 'black',
-            backgroundColor: 'transparent',
-            padding: 0,
-            font: {
-              size: 14,
-              weight: 'normal',
-            },
-          },
-          value: codeName,
-          scaleID: 'medications',
-        },
-      ],
     };
+  }
+
+  // Register the custom plugin when the service is created
+  registerCustomPlugin() {
+    Chart.register({
+      id: 'customLabels',
+      afterDatasetsDraw: (chart) => {
+        const ctx = chart.ctx;
+        chart.data.datasets.forEach((dataset, datasetIndex) => {
+          const meta = chart.getDatasetMeta(datasetIndex);
+          if (meta.yAxisID === 'medications') {
+            const label = dataset.label;
+            const centerY = (meta.data[0].y + meta.data[meta.data.length - 1].y) / 2;
+            ctx.fillStyle = 'black';
+            ctx.font = '14px Arial';
+            ctx.textAlign = 'start';
+            ctx.fillText(label!, chart.chartArea.left, centerY);
+          }
+        });
+      },
+    });
   }
 }

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/medication-request/simple-medication-mapper.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/medication-request/simple-medication-mapper.service.ts
@@ -29,10 +29,11 @@ export type MedicationDataPoint = TimelineDataPoint & {
   providedIn: 'root',
 })
 export class SimpleMedicationMapper implements Mapper<SimpleMedication> {
-  constructor(@Inject(CATEGORY_SCALE_OPTIONS) private categoryScaleOptions: ScaleOptions<'category'>, private codeService: FhirCodeService) {}
+  constructor(@Inject(CATEGORY_SCALE_OPTIONS) private categoryScaleOptions: ScaleOptions<'category'>, private codeService: FhirCodeService) {
+    this.registerCustomPlugin();
+  }
   canMap = isMedication;
   map(resource: SimpleMedication): DataLayer<TimelineChartType, MedicationDataPoint[]> {
-    this.registerCustomPlugin();
     const authoredOn = new Date(resource.authoredOn).getTime();
     const codeName = this.codeService.getName(resource?.medicationCodeableConcept);
     return {
@@ -83,6 +84,7 @@ export class SimpleMedicationMapper implements Mapper<SimpleMedication> {
             ctx.fillStyle = 'black';
             ctx.font = '14px Arial';
             ctx.textAlign = 'start';
+            ctx.textBaseline = 'middle';
             ctx.fillText(label!, chart.chartArea.left, centerY);
           }
         });


### PR DESCRIPTION
## Overview

- Added the custom plugin for simpleMedicationMapper
- Removed the annotations 
- Added the unit test cases for simpleMedicationMapper

## How it was tested

- Tested by launching the charts-on-fhir showcase app, and verified labels are showing as expected.
-  Also tested by using pack package of charts-on-fhir in the sapphire. 
- Verifed by launching hypertension and dementia app locally.

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [x] I have included screen shots for changes that affect the user interface
- [x] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)

## Screenshot

![image](https://github.com/elimuinformatics/charts-on-fhir/assets/20473487/9bcd55ac-c594-4382-b9b5-9ea0c9f1ea25)
