### PR TITLE
Single value reference range

### DIFF
--- a/libs/ngx-charts-on-fhir/package.json
+++ b/libs/ngx-charts-on-fhir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elimuinformatics/ngx-charts-on-fhir",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Charts-on-FHIR: A data visualization library for SMART-on-FHIR healthcare applications",
   "license": "Apache-2.0",
   "homepage": "https://elimuinformatics.github.io/charts-on-fhir",

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/fhir-mapper-options.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/fhir-mapper-options.ts
@@ -67,6 +67,26 @@ const defaultAnnotationOptions: ChartAnnotation = {
   drawTime: 'beforeDraw',
 };
 
+export const LINE_ANNOTATION_OPTIONS = new InjectionToken<ChartAnnotation>('Line Annotation Options', {
+  factory: () => defaultLineAnnotationOptions,
+});
+const defaultLineAnnotationOptions: ChartAnnotation = {
+  label: {
+    display: true,
+    position: 'start',
+    color: '#666666',
+    backgroundColor: '#FAFAFA',
+    font: {
+      size: 16,
+      weight: 'normal',
+    },
+  },
+  type: 'line',
+  borderWidth: 4,
+  borderColor: '#FF9999',
+  drawTime: 'beforeDraw',
+};
+
 export const TIMEFRAME_ANNOTATION_OPTIONS = new InjectionToken<ChartAnnotation>('Timeframe annotation Options', {
   factory: () => defaultTimeframeAnnotationOptions,
 });

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/reference-range.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/reference-range.service.spec.ts
@@ -1,0 +1,56 @@
+import { TestBed } from '@angular/core/testing';
+import { ANNOTATION_OPTIONS, LINE_ANNOTATION_OPTIONS } from '../fhir-mapper-options';
+import { ReferenceRangeService } from './reference-range.service';
+
+describe('ReferenceRangeService', () => {
+  let service: ReferenceRangeService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ANNOTATION_OPTIONS, useValue: { type: 'box' } },
+        { provide: LINE_ANNOTATION_OPTIONS, useValue: { type: 'line' } },
+      ],
+    });
+    service = TestBed.inject(ReferenceRangeService);
+  });
+
+  describe('getAnnotationLabel', () => {
+    it('should return the label for a range with low and high values', () => {
+      expect(service.getAnnotationLabel({ low: { value: 1 }, high: { value: 2 } }, 'Name')).toBe('Name Reference Range');
+    });
+
+    it('should return the label for a range with only a high value', () => {
+      expect(service.getAnnotationLabel({ high: { value: 2 } }, 'Name')).toBe('Name Upper Limit');
+    });
+
+    it('should return the label for a range with only a low value', () => {
+      expect(service.getAnnotationLabel({ low: { value: 1 } }, 'Name')).toBe('Name Lower Limit');
+    });
+
+    it('should return undefined for a range with no values', () => {
+      expect(service.getAnnotationLabel({}, 'Name')).toBeUndefined();
+    });
+  });
+
+  describe('createReferenceRangeAnnotation', () => {
+    it('should return a box annotation for a range with low and high values', () => {
+      const annotation = service.createReferenceRangeAnnotation({ low: { value: 1 }, high: { value: 2 } }, 'Name', 'y');
+      expect(annotation).toEqual({ type: 'box', id: 'Name Reference Range', label: { content: 'Name Reference Range' }, yScaleID: 'y', yMax: 2, yMin: 1 });
+    });
+
+    it('should return a line annotation for a range with only a high value', () => {
+      const annotation = service.createReferenceRangeAnnotation({ high: { value: 2 } }, 'Name', 'y');
+      expect(annotation).toEqual({ type: 'line', id: 'Name Upper Limit', label: { content: 'Name Upper Limit' }, scaleID: 'y', value: 2 });
+    });
+
+    it('should return a line annotation for a range with only a low value', () => {
+      const annotation = service.createReferenceRangeAnnotation({ low: { value: 1 } }, 'Name', 'y');
+      expect(annotation).toEqual({ type: 'line', id: 'Name Lower Limit', label: { content: 'Name Lower Limit' }, scaleID: 'y', value: 1 });
+    });
+
+    it('should return undefined for a range with no values', () => {
+      expect(service.createReferenceRangeAnnotation({}, 'Name', 'y')).toBeUndefined();
+    });
+  });
+});

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/reference-range.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/reference-range.service.ts
@@ -1,0 +1,59 @@
+import { Inject, Injectable } from '@angular/core';
+import { ObservationReferenceRange } from 'fhir/r4';
+import { merge } from 'lodash-es';
+import { ChartAnnotation } from '../../utils';
+import { ANNOTATION_OPTIONS, LINE_ANNOTATION_OPTIONS } from '../fhir-mapper-options';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ReferenceRangeService {
+  constructor(
+    @Inject(ANNOTATION_OPTIONS) private boxAnnotationOptions: ChartAnnotation,
+    @Inject(LINE_ANNOTATION_OPTIONS) private lineAnnotationOptions: ChartAnnotation
+  ) {}
+
+  createReferenceRangeAnnotation(range: ObservationReferenceRange, name: string, yScaleID: string): ChartAnnotation | undefined {
+    const label = this.getAnnotationLabel(range, name);
+    if (label) {
+      if (range?.low?.value && range?.high?.value) {
+        return this.createBoxAnnotation(range.high.value, range.low.value, label, yScaleID);
+      } else if (range?.high?.value) {
+        return this.createLineAnnotation(range.high.value, label, yScaleID);
+      } else if (range?.low?.value) {
+        return this.createLineAnnotation(range.low.value, label, yScaleID);
+      }
+    }
+    return undefined;
+  }
+
+  getAnnotationLabel(range: ObservationReferenceRange | undefined, name: string): string | undefined {
+    if (range?.low?.value && range?.high?.value) {
+      return `${name} Reference Range`;
+    } else if (range?.high?.value) {
+      return `${name} Upper Limit`;
+    } else if (range?.low?.value) {
+      return `${name} Lower Limit`;
+    }
+    return undefined;
+  }
+
+  private createBoxAnnotation(high: number, low: number, label: string, yScaleID: string): ChartAnnotation {
+    return merge({}, this.boxAnnotationOptions, {
+      id: label,
+      label: { content: label },
+      yScaleID,
+      yMax: high,
+      yMin: low,
+    });
+  }
+
+  private createLineAnnotation(value: number, label: string, scaleID: string): ChartAnnotation {
+    return merge({}, this.lineAnnotationOptions, {
+      id: label,
+      label: { content: label },
+      scaleID,
+      value,
+    });
+  }
+}


### PR DESCRIPTION
## Overview

- Observation mappers now create line annotations when the reference range includes only a high value or only a low value.
- Refactored reference range annotation code into a ReferenceRangeService
- This does not change the statistics service, so summary cards will not show "Out of Range" calculation for single-valued reference ranges.

## How it was tested

- Temporarily commented out high/low value in BloodPressureMapper and checked the annotations on the chart.

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [x] I have included screen shots for changes that affect the user interface
- [x] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
