### PR TITLE
default zoom to 1 year

### DIFF
--- a/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.ts
@@ -36,17 +36,19 @@ export class TimelineRangeSelectorComponent {
   ngOnInit(): void {
     this.configService.timelineRange$.pipe(delay(0)).subscribe((timelineRange) => {
       this.selectedDateRange = new DateRange(new Date(timelineRange.min), new Date(timelineRange.max));
-      if (this.configService.isAutoZoom || !this.selectedDateRange.start || !this.selectedDateRange.end) {
-        this.selectedButton = 'All';
+      if ((this.selectedButtonLabel === 'All' && this.configService.isAutoZoom) || !this.selectedDateRange.start || !this.selectedDateRange.end) {
+        this.selectedButton = 12;
+        this.updateRangeSelector(12);
       } else {
         this.selectedButton = this.calculateMonthDiff(this.selectedDateRange.start, this.selectedDateRange.end);
+        this.updateRangeSelector('All');
       }
       this.changeDetectorRef.markForCheck();
     });
   }
 
-  updateRangeSelector(monthCount: number) {
-    if (this.selectedDateRange.end && monthCount) {
+  updateRangeSelector(monthCount: number | 'All') {
+    if (this.selectedDateRange.end && monthCount && monthCount != 'All') {
       const maxDate = new Date();
       this.selectedDateRange = new DateRange(subtractMonths(maxDate, monthCount), maxDate);
       this.zoomChart();

--- a/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectorRef, Component, Input } from '@angular/core';
 import { DateRange, MatDatepickerInputEvent } from '@angular/material/datepicker';
 import { delay } from 'rxjs';
 import { FhirChartConfigurationService } from '../fhir-chart/fhir-chart-configuration.service';
-import { subtractMonths } from '../utils';
+import { MILLISECONDS_PER_DAY, subtractMonths } from '../utils';
 
 /**
  * See `*TimelineRangeSelector` for example usage.
@@ -31,7 +31,11 @@ export class TimelineRangeSelectorComponent {
   }
   @Input() showTimelineViewTitle: boolean = false;
 
-  constructor(private changeDetectorRef: ChangeDetectorRef, private configService: FhirChartConfigurationService) {}
+  constructor(
+    private changeDetectorRef: ChangeDetectorRef,
+    private configService: FhirChartConfigurationService,
+    private chartConfigService: FhirChartConfigurationService
+  ) {}
 
   ngOnInit(): void {
     this.configService.timelineRange$.pipe(delay(0)).subscribe((timelineRange) => {
@@ -39,6 +43,10 @@ export class TimelineRangeSelectorComponent {
       if ((this.selectedButtonLabel === 'All' && this.configService.isAutoZoom) || !this.selectedDateRange.start || !this.selectedDateRange.end) {
         this.selectedButton = 12;
         this.updateRangeSelector(12);
+        this.chartConfigService.zoom({
+          max: new Date().getTime(),
+          min: new Date().getTime() - 365 * MILLISECONDS_PER_DAY,
+        });
       } else {
         this.selectedButton = this.calculateMonthDiff(this.selectedDateRange.start, this.selectedDateRange.end);
         this.updateRangeSelector('All');


### PR DESCRIPTION
## Overview

- Set the initial zoom range to “1 Year” instead of “All”

## How it was tested

- Tested by launching the charts-on-fhir showcase app, and verified that the graph initially zooms to one year.
- Ran unit test cases on local.


## Checklist

- [X] The title contains a short meaningful summary
- [X] I have added a link to this PR in the Jira issue
- [X] I have described how this was tested
- [X] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [X] I have run unit tests locally
- [ ] I have updated documentation (including README)
![defaultValueTo1y](https://github.com/elimuinformatics/charts-on-fhir/assets/94971091/d422db2b-8c73-4896-8ede-fdeb143fa0f8)
