### PR TITLE
fixed DataLayerColorService overrides callback functions

### DIFF
--- a/libs/ngx-charts-on-fhir/package.json
+++ b/libs/ngx-charts-on-fhir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elimuinformatics/ngx-charts-on-fhir",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Charts-on-FHIR: A data visualization library for SMART-on-FHIR healthcare applications",
   "license": "Apache-2.0",
   "homepage": "https://elimuinformatics.github.io/charts-on-fhir",

--- a/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-color.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-color.service.spec.ts
@@ -83,6 +83,23 @@ describe('DataLayerColorService', () => {
       service.chooseColorsFromPalette(layer);
       expect(layer.annotations[0].backgroundColor).toEqual('rgba(0, 0, 0, 0.2)');
     }));
+
+    it('should ignore datasets that use a callback function for borderColor', inject([DataLayerColorService], (service: DataLayerColorService) => {
+      const borderColor = () => '#000000';
+      const layer: any = {
+        datasets: [{ label: 'One', borderColor }],
+      };
+      service.chooseColorsFromPalette(layer);
+      expect(layer.datasets[0].borderColor).toBe(borderColor);
+    }));
+    it('should ignore datasets that use a callback function for pointBackgroundColor', inject([DataLayerColorService], (service: DataLayerColorService) => {
+      const pointBackgroundColor = () => '#000000';
+      const layer: any = {
+        datasets: [{ label: 'One', pointBackgroundColor }],
+      };
+      service.chooseColorsFromPalette(layer);
+      expect(layer.datasets[0].pointBackgroundColor).toBe(pointBackgroundColor);
+    }));
   });
 
   describe('addTransparency', () => {
@@ -93,7 +110,7 @@ describe('DataLayerColorService', () => {
   });
 
   describe('getColor', () => {
-    it('should get correct annotation color by calling getColor', inject([DataLayerColorService], (service: DataLayerColorService) => {
+    it('should get the borderColor of a dataset', inject([DataLayerColorService], (service: DataLayerColorService) => {
       const dataset: any = {
         label: 'Diastolic Blood Pressure',
         yAxisID: 'mm[Hg]',
@@ -105,7 +122,7 @@ describe('DataLayerColorService', () => {
   });
 
   describe('setColor', () => {
-    it('should setColor function called', inject([DataLayerColorService], (service: DataLayerColorService) => {
+    it('should set the borderColor of a dataset', inject([DataLayerColorService], (service: DataLayerColorService) => {
       const dataset: any = { borderColor: '#e41a1c' };
       service.setColor(dataset, '#e41a1c');
       expect(dataset.borderColor).toEqual('#e41a1c');

--- a/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-color.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-color.service.ts
@@ -39,7 +39,7 @@ export class DataLayerColorService {
   /** Chooses colors for all of the datasets and annotations in the Layer by cycling through the palette */
   chooseColorsFromPalette(layer: DataLayer): void {
     for (let dataset of layer.datasets) {
-      if (!this.getColor(dataset)) {
+      if (!this.hasColor(dataset)) {
         const colorIndex = this.getMatchingDatasetColorIndex(layer, dataset) ?? this.getNextPaletteIndex();
         const palette = this.getPalette(dataset);
         const color = palette[colorIndex];
@@ -125,6 +125,11 @@ export class DataLayerColorService {
       return color;
     }
     return undefined;
+  }
+
+  hasColor(dataset: Dataset) {
+    const line = dataset as Dataset<'line'>;
+    return line.borderColor || line.backgroundColor || line.pointBorderColor || line.pointBackgroundColor;
   }
 
   /** build a CSS linear gradient that includes colors from all datasets in the layer */


### PR DESCRIPTION
## Overview

- Fixes a bug in `DataLayerColorService` where `chooseColorsFromPalette` would override the callback function for scriptable options (`borderColor`, `backgroundColor`, `pointBorderColor` or `pointBackgroundColor`)
- Fixed descriptions of some other `DataLayerColorService` unit tests 

## How it was tested

- Wrote unit tests
- Regression tested showcase and cardio app to make sure colors still get set correctly

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [x] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
