### PR TITLE
Add resource param to FhirCodeService

### DIFF
--- a/libs/ngx-charts-on-fhir/package.json
+++ b/libs/ngx-charts-on-fhir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elimuinformatics/ngx-charts-on-fhir",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Charts-on-FHIR: A data visualization library for SMART-on-FHIR healthcare applications",
   "license": "Apache-2.0",
   "homepage": "https://elimuinformatics.github.io/charts-on-fhir",

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/fhir-code.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/fhir-code.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { CodeableConcept, Coding } from 'fhir/r4';
+import { CodeableConcept, Coding, FhirResource } from 'fhir/r4';
 
 /**
  * A service for getting the display name of a FHIR `CodableConcept`.
@@ -11,7 +11,7 @@ import { CodeableConcept, Coding } from 'fhir/r4';
  * ```ts
  * @Injectable({ providedIn: 'root' })
  * export class CustomFhirCodeService extends FhirCodeService {
- *   getName(code: CodeableConcept): string {
+ *   getName(code: CodeableConcept, resource?: FhirResource): string {
  *     const customCodings = [
  *       {
  *         system: 'http://loinc.org',
@@ -42,7 +42,7 @@ import { CodeableConcept, Coding } from 'fhir/r4';
  */
 @Injectable({ providedIn: 'root' })
 export class FhirCodeService {
-  getName(code: CodeableConcept): string {
+  getName(code: CodeableConcept, resource?: FhirResource): string {
     return code.text ?? '';
   }
 }

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/medication-request/simple-medication-mapper.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/medication-request/simple-medication-mapper.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Inject } from '@angular/core';
 import { ScaleOptions, Chart } from 'chart.js';
-import { MedicationRequest } from 'fhir/r4';
+import { FhirResource, MedicationRequest } from 'fhir/r4';
 import { merge } from 'lodash-es';
 import { DataLayer, TimelineChartType, TimelineDataPoint } from '../../data-layer/data-layer';
 import { Mapper } from '../multi-mapper.service';
@@ -15,7 +15,7 @@ export type SimpleMedication = {
   };
   authoredOn: string;
 } & MedicationRequest;
-export function isMedication(resource: MedicationRequest): resource is SimpleMedication {
+export function isMedication(resource: FhirResource): resource is SimpleMedication {
   return !!(resource.resourceType === 'MedicationRequest' && resource.authoredOn && resource.medicationCodeableConcept?.text);
 }
 
@@ -35,7 +35,7 @@ export class SimpleMedicationMapper implements Mapper<SimpleMedication> {
   canMap = isMedication;
   map(resource: SimpleMedication): DataLayer<TimelineChartType, MedicationDataPoint[]> {
     const authoredOn = new Date(resource.authoredOn).getTime();
-    const codeName = this.codeService.getName(resource?.medicationCodeableConcept);
+    const codeName = this.codeService.getName(resource?.medicationCodeableConcept, resource);
     return {
       name: 'Prescribed Medications',
       category: ['medication'],

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/component-observation-mapper.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/component-observation-mapper.service.ts
@@ -54,13 +54,13 @@ export class ComponentObservationMapper implements Mapper<ComponentObservation> 
   ) {}
   canMap = isComponentObservation;
   map(resource: ComponentObservation, overrideLayerName?: string): DataLayer {
-    const codeName = this.codeService.getName(resource.code);
+    const codeName = this.codeService.getName(resource.code, resource);
     const layerName = overrideLayerName ?? codeName;
     return {
       name: layerName,
       category: resource.category?.flatMap((c) => c.coding?.map((coding) => coding.display)).filter(isDefined),
       datasets: resource.component.map((component) => ({
-        label: this.codeService.getName(component.code) + getMeasurementSettingSuffix(resource),
+        label: this.codeService.getName(component.code, resource) + getMeasurementSettingSuffix(resource),
         yAxisID: layerName,
         data: [
           {
@@ -70,10 +70,13 @@ export class ComponentObservationMapper implements Mapper<ComponentObservation> 
           },
         ],
         chartsOnFhir: {
-          group: this.codeService.getName(component.code),
+          group: this.codeService.getName(component.code, resource),
           colorPalette: isHomeMeasurement(resource) ? 'light' : 'dark',
           tags: [isHomeMeasurement(resource) ? 'Home' : 'Clinic'],
-          referenceRangeAnnotation: this.referenceRangeService.getAnnotationLabel(component.referenceRange?.[0], this.codeService.getName(component.code)),
+          referenceRangeAnnotation: this.referenceRangeService.getAnnotationLabel(
+            component.referenceRange?.[0],
+            this.codeService.getName(component.code, resource)
+          ),
         },
       })),
       scale: merge({}, this.linearScaleOptions, {
@@ -84,7 +87,7 @@ export class ComponentObservationMapper implements Mapper<ComponentObservation> 
       annotations: resource.component
         .flatMap((component) =>
           component.referenceRange?.map((range) =>
-            this.referenceRangeService.createReferenceRangeAnnotation(range, this.codeService.getName(component.code), layerName)
+            this.referenceRangeService.createReferenceRangeAnnotation(range, this.codeService.getName(component.code, resource), layerName)
           )
         )
         .filter(isDefined),

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/simple-observation-mapper.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/simple-observation-mapper.service.ts
@@ -45,7 +45,7 @@ export class SimpleObservationMapper implements Mapper<SimpleObservation> {
   ) {}
   canMap = isSimpleObservation;
   map(resource: SimpleObservation, overrideLayerName?: string): DataLayer {
-    const codeName = this.codeService.getName(resource.code);
+    const codeName = this.codeService.getName(resource.code, resource);
     const layerName = overrideLayerName ?? codeName;
     return {
       name: layerName,


### PR DESCRIPTION
## Overview

- Adds a `resource` param to `FhirCodeService.getName()`
- This allows a custom implementation to use other resource properties (e.g. extensions) to determine the name

## How it was tested

- Ran unit tests

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
