### PR TITLE
Handled the dataLayerService to continue loading data from the other services when one of service the service fails

### DIFF
--- a/libs/ngx-charts-on-fhir/package.json
+++ b/libs/ngx-charts-on-fhir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elimuinformatics/ngx-charts-on-fhir",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "description": "Charts-on-FHIR: A data visualization library for SMART-on-FHIR healthcare applications",
   "license": "Apache-2.0",
   "homepage": "https://elimuinformatics.github.io/charts-on-fhir",

--- a/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-manager.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-manager.service.spec.ts
@@ -65,7 +65,7 @@ describe('DataLayerManagerService', () => {
       const manager = new DataLayerManagerService(servicesWithError, colorService, tagsService, mergeService);
       spyOn(console, 'error');
       manager.retrieveAll();
-      expect(manager.dataRetrievalError).toBe(true);
+      expect(manager.dataRetrievalError$.getValue()).toBe(true);
       expect(console.error).toHaveBeenCalledWith(error);
       expect(manager.loading$.getValue()).toBe(false);
       expect(mergeService.merge).toHaveBeenCalledWith({}, a);

--- a/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-manager.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-manager.service.ts
@@ -163,6 +163,7 @@ export class DataLayerManagerService {
   reset() {
     this.cancel$.next();
     this.state = { ...this.state, layers: {}, selected: [] };
+    this.dataRetrievalError$.next(false);
   }
 
   /**

--- a/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-manager.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-manager.service.ts
@@ -88,7 +88,7 @@ export class DataLayerManagerService {
     private tagsService: FhirChartTagsService,
     private mergeService: DataLayerMergeService
   ) {}
-  dataRetrievalError = false;
+  dataRetrievalError$ = new BehaviorSubject<boolean>(false);
   private stateSubject = new BehaviorSubject(initialState);
   private get state() {
     return this.stateSubject.value;
@@ -140,7 +140,7 @@ export class DataLayerManagerService {
       ...this.dataLayerServices.map((service) =>
         service.retrieve().pipe(
           catchError((error) => {
-            this.dataRetrievalError = true;
+            this.dataRetrievalError$.next(true);
             console.error(error);
             return EMPTY;
           })

--- a/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-manager.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer-manager.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@angular/core';
-import { BehaviorSubject, distinctUntilChanged, map, merge, Observable, Subject, takeUntil } from 'rxjs';
+import { BehaviorSubject, catchError, distinctUntilChanged, EMPTY, map, merge, Observable, Subject, takeUntil } from 'rxjs';
 import { DataLayer, DataLayerCollection, ManagedDataLayer } from './data-layer';
 import { DataLayerColorService } from './data-layer-color.service';
 import { DataLayerMergeService } from './data-layer-merge.service';
@@ -88,7 +88,7 @@ export class DataLayerManagerService {
     private tagsService: FhirChartTagsService,
     private mergeService: DataLayerMergeService
   ) {}
-
+  dataRetrievalError = false;
   private stateSubject = new BehaviorSubject(initialState);
   private get state() {
     return this.stateSubject.value;
@@ -136,16 +136,22 @@ export class DataLayerManagerService {
   retrieveAll() {
     this.reset();
     this.loading$.next(true);
-    merge(...this.dataLayerServices.map((service) => service.retrieve()))
+    merge(
+      ...this.dataLayerServices.map((service) =>
+        service.retrieve().pipe(
+          catchError((error) => {
+            this.dataRetrievalError = true;
+            console.error(error);
+            return EMPTY;
+          })
+        )
+      )
+    )
       .pipe(takeUntil(this.cancel$))
       .subscribe({
         next: (layer) => {
           const layers = this.mergeService.merge(this.state.layers, layer);
           this.state = { ...this.state, layers };
-        },
-        error: (err) => {
-          console.error(err);
-          this.loading$.next(false);
         },
         complete: () => {
           this.loading$.next(false);

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.css
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.css
@@ -37,6 +37,7 @@
 }
 
 .error-msg {
+  position: absolute;
   text-align: left;
   color: red;
 }

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.css
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.css
@@ -35,3 +35,8 @@
   padding: 4px;
   pointer-events: all;
 }
+
+.error-msg {
+  text-align: left;
+  color: red;
+}

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.html
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.html
@@ -1,6 +1,7 @@
 <div class="chart-container" [style.width]="width" [style.height]="height">
   <div class="chart-container-resize-fix">
     <ng-container *ngIf="datasets && datasets.length > 0; else empty">
+      <div class="error-msg" *ngIf="layerManager.dataRetrievalError">Some data is missing</div>
       <canvas width="100%" baseChart id="baseChart" [type]="type ?? defaultType" [datasets]="datasets" [options]="options ?? defaultOptions"></canvas>
       <div class="floating-content-container">
         <div *ngIf="floatingContent" class="floating-content mat-elevation-z2" cdkDrag cdkDragBoundary=".chart-container">

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.html
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.html
@@ -1,7 +1,7 @@
 <div class="chart-container" [style.width]="width" [style.height]="height">
   <div class="chart-container-resize-fix">
     <ng-container *ngIf="datasets && datasets.length > 0; else empty">
-      <div class="error-msg" *ngIf="layerManager.dataRetrievalError">Some data is missing</div>
+      <div class="error-msg" *ngIf="layerManager.dataRetrievalError$ | async">There was a problem retrieving data. The timeline may be incomplete.</div>
       <canvas width="100%" baseChart id="baseChart" [type]="type ?? defaultType" [datasets]="datasets" [options]="options ?? defaultOptions"></canvas>
       <div class="floating-content-container">
         <div *ngIf="floatingContent" class="floating-content mat-elevation-z2" cdkDrag cdkDragBoundary=".chart-container">


### PR DESCRIPTION
## Overview

- Updated the dataLayerService to continue loading data from the other services when one of services throws an error while retrieving data


## How it was tested

- Tested by intentionally failing a service call and launching the charts-on-fhir showcase app locally.


## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [x] I have included screen shots for changes that affect the user interface
- [x] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)


## Screenshot
![image](https://github.com/elimuinformatics/charts-on-fhir/assets/20473487/1daefa99-760b-4ae2-a1f5-5cca72c12a40)


