### PR TITLE
OT-1151: Configure json logging for showcase,cardio and cardio-patient services

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -10,8 +10,12 @@ events {
 daemon off;
 
 http {
+
+  log_format  main  escape=json '{"remote_address": "$remote_addr", "remote_user": "$remote_user", "time" : "$time_local", "request": "$request", "status": "$status", "body_bytes_sent": "$body_bytes_sent", "referer": "$http_referer","http_user_agent": "$http_user_agent", "http_x_forwrded_for": "$http_x_forwarded_for"}';
+
   server {
     listen 80;
+    access_log /var/log/nginx/access.log main;
     root /usr/share/nginx/html;
     include /etc/nginx/mime.types;
 


### PR DESCRIPTION
## Overview

- Added log_format to enable json logging for the below services.
  - showcase-web
  - cardio-patient-web		
  - cardio-web

## How it was tested

- Tested by running the application locally and checked container logs.


## Checklist

- [X] The title contains a short meaningful summary
- [X] I have added a link to this PR in the Jira issue
- [X] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)
