### PR TITLE
RT-1327:(charts-on-fhir) Observation mapper creates multiple layers

### DIFF
--- a/libs/ngx-charts-on-fhir/package.json
+++ b/libs/ngx-charts-on-fhir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elimuinformatics/ngx-charts-on-fhir",
-  "version": "3.4.5",
+  "version": "3.4.6",
   "description": "Charts-on-FHIR: A data visualization library for SMART-on-FHIR healthcare applications",
   "license": "Apache-2.0",
   "homepage": "https://elimuinformatics.github.io/charts-on-fhir",

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/component-observation-mapper.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/component-observation-mapper.service.spec.ts
@@ -155,7 +155,7 @@ describe('ComponentObservationMapper', () => {
         resourceType: 'Observation',
         status: 'final',
         code: { text: 'text' },
-        category: [{ coding: [{ display: 'A' }] }, { coding: [{ display: 'B' }] }],
+        category: [{ coding: [{ code: 'A' }] }, { coding: [{ code: 'B' }] }],
         effectiveDateTime: new Date().toISOString(),
         component: [
           {

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/component-observation-mapper.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/component-observation-mapper.service.ts
@@ -58,7 +58,7 @@ export class ComponentObservationMapper implements Mapper<ComponentObservation> 
     const layerName = overrideLayerName ?? codeName;
     return {
       name: layerName,
-      category: resource.category?.flatMap((c) => c.coding?.map((coding) => coding.display)).filter(isDefined),
+      category: resource.category?.flatMap((c) => c.coding?.map((coding) => coding.code)).filter(isDefined),
       datasets: resource.component.map((component) => ({
         label: this.codeService.getName(component.code, resource) + getMeasurementSettingSuffix(resource),
         yAxisID: layerName,

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/simple-observation-mapper.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/simple-observation-mapper.service.spec.ts
@@ -111,7 +111,7 @@ describe('SimpleObservationMapper', () => {
         resourceType: 'Observation',
         status: 'final',
         code: { text: 'text' },
-        category: [{ coding: [{ display: 'A' }] }, { coding: [{ display: 'B' }] }],
+        category: [{ coding: [{ code: 'A' }] }, { coding: [{ code: 'B' }] }],
         effectiveDateTime: new Date().toISOString(),
         valueQuantity: { value: 7, unit: 'unit' },
       };

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/simple-observation-mapper.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/simple-observation-mapper.service.ts
@@ -49,7 +49,7 @@ export class SimpleObservationMapper implements Mapper<SimpleObservation> {
     const layerName = overrideLayerName ?? codeName;
     return {
       name: layerName,
-      category: resource.category?.flatMap((c) => c.coding?.map((coding) => coding.display)).filter(isDefined),
+      category: resource.category?.flatMap((c) => c.coding?.map((coding) => coding.code)).filter(isDefined),
       datasets: [
         {
           label: codeName + getMeasurementSettingSuffix(resource),


### PR DESCRIPTION
## Overview

Used category.code for group observations using category

## How it was tested
Created two observations with different category.display and reproduce an issue on the local 
It was tested by the same observations after being fixed.




## Checklist

- [X ] The title contains a short meaningful summary
- [X ] I have added a link to this PR in the Jira issue
- [X ] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [X ] I have updated unit tests
- [X ] I have run unit tests locally
- [ ] I have updated documentation (including README)
