### PR TITLE
Rt 1322 encounter labels are drawn behind

### DIFF
--- a/libs/ngx-charts-on-fhir/package.json
+++ b/libs/ngx-charts-on-fhir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elimuinformatics/ngx-charts-on-fhir",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "description": "Charts-on-FHIR: A data visualization library for SMART-on-FHIR healthcare applications",
   "license": "Apache-2.0",
   "homepage": "https://elimuinformatics.github.io/charts-on-fhir",

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart.component.ts
@@ -37,7 +37,7 @@ export class FhirChartComponent implements OnInit {
   constructor(private configService: FhirChartConfigurationService, public layerManager: DataLayerManagerService) {}
 
   ngOnInit(): void {
-    Chart.register(annotationPlugin, zoomPlugin, scaleStackDividerPlugin);
+    Chart.register(scaleStackDividerPlugin, annotationPlugin, zoomPlugin);
 
     // To responsively resize the chart based on its container size, we must set maintainAspectRatio = false
     Chart.defaults.maintainAspectRatio = false;


### PR DESCRIPTION
## Overview

- Changed the order in which plugins are registered so annotations will be drawn after scale dividers

## How it was tested

- Ran showcase app with mock fhir server and checked that encounter labels are not cut off when they overlap the divider

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [x] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)

![image](https://github.com/elimuinformatics/charts-on-fhir/assets/2105775/e5096b96-0c30-4908-80f8-c2c8824dd816)

