### PR TITLE
RT-1384 (charts-on-fhir) Customize tooltip title

### DIFF
--- a/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer.ts
@@ -9,6 +9,7 @@ export type TimelineDataPoint = {
   y: number | string;
   tooltip?: string | string[];
   resource?: any;
+  tooltipTitle?: string;
 };
 
 export type TimelineScaleType = 'linear' | 'category';
@@ -20,6 +21,7 @@ export type DataLayer<T extends ChartType = TimelineChartType, D = TimelineDataP
   scale: ScaleOptions & { id: string };
   datasets: Dataset<T, D>[];
   annotations?: ChartAnnotations;
+  tooltipTitle?: string;
 };
 
 /** Extends the Chart.js `ChartDataset` type with additional options that are used by Charts-on-FHIR Angular services */

--- a/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/data-layer/data-layer.ts
@@ -21,7 +21,6 @@ export type DataLayer<T extends ChartType = TimelineChartType, D = TimelineDataP
   scale: ScaleOptions & { id: string };
   datasets: Dataset<T, D>[];
   annotations?: ChartAnnotations;
-  tooltipTitle?: string;
 };
 
 /** Extends the Chart.js `ChartDataset` type with additional options that are used by Charts-on-FHIR Angular services */

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.spec.ts
@@ -669,4 +669,19 @@ describe('FhirChartConfigurationService', () => {
     const callback = config.options!.plugins!.tooltip!.callbacks!.title!.bind({} as any);
     expect(callback(tooltipItems)).toEqual(['1 Jan 2023 12:00 AM']);
   });
+
+  it('should use tooltipTitle as tooltip title if tooltipTitle present', () => {
+    const dataset: Dataset = {
+      label: 'Test',
+      yAxisID: 'scale',
+      data: [{ x: new Date('2023-01-01T00:00').getTime(), y: 1, tooltipTitle: 'title' }],
+    };
+    const scale = { id: 'scale', type: 'category' } as const;
+    const layerManager: any = { selectedLayers$: EMPTY };
+    const configService = new FhirChartConfigurationService(layerManager, timeScaleOptions, timeframeAnnotationOptions, ngZone);
+    const config = configService.buildConfiguration([dataset], { scale }, []);
+    const tooltipItems = [{ raw: dataset.data[0] }] as TooltipItem<TimelineChartType>[];
+    const callback = config.options!.plugins!.tooltip!.callbacks!.title!.bind({} as any);
+    expect(callback(tooltipItems)).toEqual(['title']);
+  });
 });

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.ts
@@ -213,7 +213,9 @@ const datasetMergeCustomizer = (_objValue: any, srcValue: any, key: any) => {
 
 const getTooltipTitle = (item: TooltipItem<TimelineChartType>) => {
   const dataPoint = item.raw as TimelineDataPoint;
-  if (typeof dataPoint.y === 'string') {
+  if (dataPoint.tooltipTitle) {
+    return dataPoint.tooltipTitle;
+  } else if (typeof dataPoint.y === 'string') {
     return dataPoint.y;
   }
   const x = Array.isArray(dataPoint.x) ? dataPoint.x : [dataPoint.x];


### PR DESCRIPTION
## Overview

When creating a custom mapper, we can customize the tooltip title to use something other than the y-value for category scales.

## How it was tested

I ran the showcase app and checked the graphs by adding a tooltipTitle in its mappers.
## Checklist

- [X] The title contains a short meaningful summary
- [X] I have added a link to this PR in the Jira issue
- [X] I have described how this was tested
- [X] I have included screen shots for changes that affect the user interface
- [X] I have updated unit tests
- [X] I have run unit tests locally
- [ ] I have updated documentation (including README)
