### PR TITLE
Update dataset label mappings in Observation mapper

### DIFF
--- a/libs/ngx-charts-on-fhir/package.json
+++ b/libs/ngx-charts-on-fhir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elimuinformatics/ngx-charts-on-fhir",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "Charts-on-FHIR: A data visualization library for SMART-on-FHIR healthcare applications",
   "license": "Apache-2.0",
   "homepage": "https://elimuinformatics.github.io/charts-on-fhir",

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/component-observation-mapper.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/component-observation-mapper.service.spec.ts
@@ -67,10 +67,7 @@ describe('ComponentObservationMapper', () => {
           },
         ],
       };
-      expect(mapper.map(observation).datasets).toEqual([
-        jasmine.objectContaining({ label: 'one (Clinic)' }),
-        jasmine.objectContaining({ label: 'two (Clinic)' }),
-      ]);
+      expect(mapper.map(observation).datasets).toEqual([jasmine.objectContaining({ label: 'one' }), jasmine.objectContaining({ label: 'two' })]);
     });
 
     it('should map effectiveDateTime to x value in milliseconds', () => {
@@ -124,7 +121,7 @@ describe('ComponentObservationMapper', () => {
           id: 'text',
           type: 'linear',
           title: { text: ['text', 'code'] },
-        })
+        }),
       );
     });
 
@@ -153,7 +150,7 @@ describe('ComponentObservationMapper', () => {
           yScaleID: 'text',
           yMin: 1,
           yMax: 10,
-        })
+        }),
       );
     });
 

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/simple-observation-mapper.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/observation/simple-observation-mapper.service.ts
@@ -10,7 +10,6 @@ import { FhirCodeService } from '../fhir-code.service';
 import { ReferenceRangeService } from './reference-range.service';
 
 export const HOME_DATASET_LABEL_SUFFIX = ' (Home)';
-export const CLINIC_DATASET_LABEL_SUFFIX = ' (Clinic)';
 
 /** Required properties for mapping an Observation with `SimpleObservationMapper` */
 export type SimpleObservation = {
@@ -41,7 +40,7 @@ export class SimpleObservationMapper implements Mapper<SimpleObservation> {
   constructor(
     @Inject(LINEAR_SCALE_OPTIONS) private readonly linearScaleOptions: ScaleOptions<'linear'>,
     private readonly codeService: FhirCodeService,
-    private readonly referenceRangeService: ReferenceRangeService
+    private readonly referenceRangeService: ReferenceRangeService,
   ) {}
   canMap = isSimpleObservation;
   map(resource: SimpleObservation, overrideLayerName?: string): DataLayer {
@@ -83,7 +82,7 @@ export class SimpleObservationMapper implements Mapper<SimpleObservation> {
 export const measurementSettingExtUrl = 'http://hl7.org/fhir/us/vitals/StructureDefinition/MeasurementSettingExt';
 export const homeEnvironmentCode = '264362003';
 export function getMeasurementSettingSuffix(resource: Observation): string {
-  return isHomeMeasurement(resource) ? HOME_DATASET_LABEL_SUFFIX : CLINIC_DATASET_LABEL_SUFFIX;
+  return isHomeMeasurement(resource) ? HOME_DATASET_LABEL_SUFFIX : '';
 }
 export function isHomeMeasurement(resource: Observation): boolean {
   if (resource.extension) {


### PR DESCRIPTION
## Overview

- Removed a “(Clinic)” suffix to the dataset label when charts-on-fhir maps an observation without a Measurement Setting extension
- Updated related unit test.


## How it was tested

-  Tested by building charts-on-fhir and used locally with sapphire app.
-  Verified that a “(Clinic)” suffix to the dataset label is not added when it maps an observation without a Measurement Setting extension


## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [x] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
