### PR TITLE
Enhance annotation value extraction in computeBounds function

### DIFF
--- a/libs/ngx-charts-on-fhir/package.json
+++ b/libs/ngx-charts-on-fhir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elimuinformatics/ngx-charts-on-fhir",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "description": "Charts-on-FHIR: A data visualization library for SMART-on-FHIR healthcare applications",
   "license": "Apache-2.0",
   "homepage": "https://elimuinformatics.github.io/charts-on-fhir",

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-chart/fhir-chart-configuration.service.ts
@@ -10,6 +10,7 @@ import { TIME_SCALE_OPTIONS, TIMEFRAME_ANNOTATION_OPTIONS } from '../fhir-mapper
 import { ChartAnnotation, ChartAnnotations, ChartScales, formatDateTime, formatMonths, isDefined, MonthRange, NumberRange, subtractMonths } from '../utils';
 import './center-tooltip-positioner';
 import { sortData } from '../data-layer/data-layer-merge.service';
+import { LineAnnotationOptions } from 'chartjs-plugin-annotation';
 export type TimelineConfiguration = ChartConfiguration<TimelineChartType, TimelineDataPoint[]>;
 
 type MergedDataLayer = {
@@ -273,7 +274,8 @@ function computeBounds(axis: 'x' | 'y', padding: number, datasets: Dataset[], an
         const annotationValues: number[] = [];
         if (isNotNaN(anno[annoMin])) annotationValues.push(anno[annoMin]);
         if (isNotNaN(anno[annoMax])) annotationValues.push(anno[annoMax]);
-        if (isNotNaN((anno as any).value)) annotationValues.push((anno as any).value);
+        const annoValue = (anno as LineAnnotationOptions).value;
+        if (isNotNaN(annoValue)) annotationValues.push(annoValue);
         return annotationValues;
       }),
     );


### PR DESCRIPTION
## Overview
Updated computeBounds function in FhirChartConfigurationService to support line annotations, having a value property instead of yMin and yMax.


## How it was tested
Tested by launching showcase locally with different values off BPs


## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [x] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)

##Screenshot
![image](https://github.com/user-attachments/assets/eee3cd23-6a01-408c-b62b-7dd47ec941f5)
![image](https://github.com/user-attachments/assets/cc633d3e-9043-47c5-a881-42c302f1ba93)

