### PR TITLE
Fixed timing codes used in medication duration calculation

### DIFF
--- a/libs/ngx-charts-on-fhir/package.json
+++ b/libs/ngx-charts-on-fhir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elimuinformatics/ngx-charts-on-fhir",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Charts-on-FHIR: A data visualization library for SMART-on-FHIR healthcare applications",
   "license": "Apache-2.0",
   "homepage": "https://elimuinformatics.github.io/charts-on-fhir",

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/medication-request/duration-medication-mapper.service.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/medication-request/duration-medication-mapper.service.spec.ts
@@ -455,6 +455,49 @@ describe('DurationMedicationMapper', () => {
       expect(mapper.map(medication).datasets[0].data[0].x).toEqual([expectedStartDate, expectedEndDate]);
     });
 
+    it('should compute duration for a TimingCodeMedication with uppercase code', () => {
+      const medication: TimingCodeMedication = {
+        ...basicMedication,
+        dosageInstruction: [
+          {
+            timing: {
+              code: {
+                coding: [
+                  {
+                    system: 'http://www.example.com/proprietary-code-system',
+                    code: 'never',
+                  },
+                  {
+                    system: timingAbbreviationCodeSystem,
+                    code: 'QD',
+                  },
+                ],
+              },
+            },
+            doseAndRate: [
+              {
+                doseQuantity: {
+                  value: 10,
+                  code: 'mg',
+                },
+              },
+            ],
+          },
+        ],
+        dispenseRequest: {
+          initialFill: {
+            quantity: {
+              value: 300,
+              code: 'mg',
+            },
+          },
+        },
+      };
+      const expectedStartDate = new Date(medication.authoredOn).getTime();
+      const expectedEndDate = new Date('2023-01-31T00:00:00Z').getTime();
+      expect(mapper.map(medication).datasets[0].data[0].x).toEqual([expectedStartDate, expectedEndDate]);
+    });
+
     it('should throw an error for invalid Timing code', () => {
       const medication: TimingCodeMedication = {
         ...basicMedication,
@@ -536,6 +579,38 @@ describe('DurationMedicationMapper', () => {
           {
             timing: {
               code: { text: 'daily' },
+            },
+            doseAndRate: [
+              {
+                doseQuantity: {
+                  value: 10,
+                  code: 'mg',
+                },
+              },
+            ],
+          },
+        ],
+        dispenseRequest: {
+          initialFill: {
+            quantity: {
+              value: 300,
+              code: 'mg',
+            },
+          },
+        },
+      };
+      const expectedStartDate = new Date(medication.authoredOn).getTime();
+      const expectedEndDate = new Date('2023-01-31T00:00:00Z').getTime();
+      expect(mapper.map(medication).datasets[0].data[0].x).toEqual([expectedStartDate, expectedEndDate]);
+    });
+
+    it('should compute duration for a TimingTextMedication with uppercase text', () => {
+      const medication: TimingTextMedication = {
+        ...basicMedication,
+        dosageInstruction: [
+          {
+            timing: {
+              code: { text: 'Daily' },
             },
             doseAndRate: [
               {

--- a/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/medication-request/duration-medication-mapper.service.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/fhir-mappers/medication-request/duration-medication-mapper.service.ts
@@ -170,7 +170,7 @@ export type TimingTextMedication = {
 export function isTimingTextMedication(resource: MedicationRequest): resource is TimingTextMedication {
   return (
     isTimingMedication(resource) && //
-    resource.dosageInstruction[0].timing?.code?.text === 'daily'
+    resource.dosageInstruction[0].timing?.code?.text?.toLowerCase() === 'daily'
   );
 }
 
@@ -277,14 +277,15 @@ function computeDailyFrequency(resource: TimingMedication) {
       q8h: 3,
       bed: 1,
       week: 1 / 7,
+      wk: 1 / 7,
       mo: 1 / 30,
     };
     const coding = resource.dosageInstruction[0].timing.code.coding.find(({ system }) => system === timingAbbreviationCodeSystem);
-    if (coding?.code && timingCodeFrequency[coding.code] != null) {
-      return timingCodeFrequency[coding.code];
+    if (coding?.code && timingCodeFrequency[coding.code.toLowerCase()] != null) {
+      return timingCodeFrequency[coding.code.toLowerCase()];
     }
   } else if (isTimingTextMedication(resource)) {
-    if (resource.dosageInstruction[0].timing.code.text === 'daily') {
+    if (resource.dosageInstruction[0].timing.code.text.toLowerCase() === 'daily') {
       return 1;
     }
   }


### PR DESCRIPTION
## Overview

- Fixed MedicationDurationMapper so timing codes are not case sensitive
- Added missing timing code `WK`

## How it was tested

- Added unit tests to cover uppercase timing codes
- Ran unit tests locally

## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [ ] I have included screen shots for changes that affect the user interface
- [x] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)
