### PR TITLE
Set max date to end of day when converting range strings in TimelineRangeSelector

### DIFF
--- a/libs/ngx-charts-on-fhir/package.json
+++ b/libs/ngx-charts-on-fhir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elimuinformatics/ngx-charts-on-fhir",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "description": "Charts-on-FHIR: A data visualization library for SMART-on-FHIR healthcare applications",
   "license": "Apache-2.0",
   "homepage": "https://elimuinformatics.github.io/charts-on-fhir",

--- a/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.spec.ts
@@ -76,7 +76,7 @@ describe('TimelineRangeSelectorComponent', () => {
     component.buttons = ['2 d'];
     let ButtonInput = await loader.getHarness(MatButtonToggleHarness.with({ text: '2 d' }));
     await ButtonInput.check();
-    const expectedMinDate = new Date('2022-03-28T00:00');
+    const expectedMinDate = new Date('2022-03-28T23:59:59.999');
     expect(component.selectedDateRange.start).toEqual(expectedMinDate);
   });
 
@@ -84,7 +84,7 @@ describe('TimelineRangeSelectorComponent', () => {
     jasmine.clock().mockDate(new Date('2022-03-30T00:00'));
     let ButtonInputGroup = await loader.getHarness(MatButtonToggleHarness.with({ text: '1 mo' }));
     await ButtonInputGroup.check();
-    const expectedMinDate = new Date('2022-02-28T00:00');
+    const expectedMinDate = new Date('2022-02-28T23:59:59.999');
     expect(component.selectedDateRange.start).toEqual(expectedMinDate);
   });
 
@@ -92,7 +92,7 @@ describe('TimelineRangeSelectorComponent', () => {
     jasmine.clock().mockDate(new Date('2022-03-30T00:00'));
     let ButtonInput = await loader.getHarness(MatButtonToggleHarness.with({ text: '3 mo' }));
     await ButtonInput.check();
-    const expectedMinDate = new Date('2021-12-30T00:00');
+    const expectedMinDate = new Date('2021-12-30T23:59:59.999');
     expect(component.selectedDateRange.start).toEqual(expectedMinDate);
   });
 
@@ -100,7 +100,7 @@ describe('TimelineRangeSelectorComponent', () => {
     jasmine.clock().mockDate(new Date('2022-03-30T00:00'));
     let ButtonInput = await loader.getHarness(MatButtonToggleHarness.with({ text: '6 mo' }));
     await ButtonInput.check();
-    const expectedMinDate = new Date('2021-09-30T00:00');
+    const expectedMinDate = new Date('2021-09-30T23:59:59.999');
     expect(component.selectedDateRange.start).toEqual(expectedMinDate);
   });
 
@@ -108,7 +108,7 @@ describe('TimelineRangeSelectorComponent', () => {
     jasmine.clock().mockDate(new Date('2022-03-30T00:00'));
     let ButtonInput = await loader.getHarness(MatButtonToggleHarness.with({ text: '1 y' }));
     await ButtonInput.check();
-    const expectedMinDate = new Date('2021-03-30T00:00');
+    const expectedMinDate = new Date('2021-03-30T23:59:59.999');
     expect(component.selectedDateRange.start).toEqual(expectedMinDate);
   });
 

--- a/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.ts
@@ -124,6 +124,7 @@ export class TimelineRangeSelectorComponent {
       return new DateRange<Date>(null, null);
     }
     const maxDate = new Date();
+    maxDate.setHours(23, 59, 59, 999);
     const [value, unit] = rangeString.split(' ');
     if (unit === 'y') {
       return new DateRange<Date>(subtractMonths(maxDate, parseInt(value) * 12), maxDate);


### PR DESCRIPTION
## Overview

- Set max date to end of day when converting range strings in TimelineRangeSelector


## How it was tested

- Tested locally with mock data.
- Tested by running unit tests.


## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [x] I have included screen shots for changes that affect the user interface
- [x] I have updated unit tests
- [x] I have run unit tests locally
- [ ] I have updated documentation (including README)

![Screenshot from 2025-04-22 16-49-20](https://github.com/user-attachments/assets/6586ca4b-a48e-493e-8fa3-0b3fb10f0d67)

![Screenshot from 2025-04-22 18-37-20](https://github.com/user-attachments/assets/ae67de8b-d378-4907-b692-ed018e3d1bc3)
