### PR TITLE
RT-2081: Timeline range selector custom end date

### DIFF
--- a/libs/ngx-charts-on-fhir/package.json
+++ b/libs/ngx-charts-on-fhir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elimuinformatics/ngx-charts-on-fhir",
-  "version": "8.0.4",
+  "version": "8.0.5",
   "description": "Charts-on-FHIR: A data visualization library for SMART-on-FHIR healthcare applications",
   "license": "Apache-2.0",
   "homepage": "https://elimuinformatics.github.io/charts-on-fhir",

--- a/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.spec.ts
@@ -19,6 +19,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatCalendarHarness, MatDateRangeInputHarness } from '@angular/material/datepicker/testing';
 import { MatMenuHarness } from '@angular/material/menu/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
+import { fakeAsync, tick } from '@angular/core/testing';
 
 const max = new Date('2022-03-30T00:00').getTime();
 const min = new Date('2022-01-06T00:00').getTime();
@@ -118,19 +119,21 @@ describe('TimelineRangeSelectorComponent', () => {
     expect(mockConfigService.resetZoom).toHaveBeenCalled();
   });
 
-  it('should check dateChange selected event for start date', () => {
+  it('should check dateChange selected event for start date', fakeAsync(() => {
     const date: any = { value: new Date(2020, 2, 2) };
     component.dateChange(date, 'min');
+    tick();
     fixture.detectChanges();
     expect(component.selectedDateRange.start).toEqual(date.value);
-  });
+  }));
 
-  it('should check dateChange selected event for end date', () => {
+  it('should check dateChange selected event for end date', fakeAsync(() => {
     const date: any = { value: new Date(2020, 2, 2) };
     component.dateChange(date, 'max');
+    tick();
     fixture.detectChanges();
     expect(component.selectedDateRange.end).toEqual(date.value);
-  });
+  }));
 
   it('should check month difference between two dates', async () => {
     const componentMaxdate = new Date('2022-01-01T00:00');

--- a/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.spec.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.spec.ts
@@ -19,7 +19,6 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatCalendarHarness, MatDateRangeInputHarness } from '@angular/material/datepicker/testing';
 import { MatMenuHarness } from '@angular/material/menu/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
-import { fakeAsync, tick } from '@angular/core/testing';
 
 const max = new Date('2022-03-30T00:00').getTime();
 const min = new Date('2022-01-06T00:00').getTime();
@@ -119,21 +118,19 @@ describe('TimelineRangeSelectorComponent', () => {
     expect(mockConfigService.resetZoom).toHaveBeenCalled();
   });
 
-  it('should check dateChange selected event for start date', fakeAsync(() => {
+  it('should check dateChange selected event for start date', () => {
     const date: any = { value: new Date(2020, 2, 2) };
     component.dateChange(date, 'min');
-    tick();
     fixture.detectChanges();
     expect(component.selectedDateRange.start).toEqual(date.value);
-  }));
+  });
 
-  it('should check dateChange selected event for end date', fakeAsync(() => {
+  it('should check dateChange selected event for end date', () => {
     const date: any = { value: new Date(2020, 2, 2) };
     component.dateChange(date, 'max');
-    tick();
     fixture.detectChanges();
     expect(component.selectedDateRange.end).toEqual(date.value);
-  }));
+  });
 
   it('should check month difference between two dates', async () => {
     const componentMaxdate = new Date('2022-01-01T00:00');

--- a/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.ts
@@ -64,12 +64,12 @@ export class TimelineRangeSelectorComponent {
   }
 
   dateChange(event: MatDatepickerInputEvent<Date>, datePickerType: string) {
+    if (datePickerType === 'min') {
+      this.selectedDateRange = new DateRange(event.value, this.selectedDateRange.end);
+    } else {
+      this.selectedDateRange = new DateRange(this.selectedDateRange.start, event.value);
+    }
     setTimeout(() => {
-      if (datePickerType === 'min') {
-        this.selectedDateRange = new DateRange(event.value, this.selectedDateRange.end);
-      } else {
-        this.selectedDateRange = new DateRange(this.selectedDateRange.start, event.value);
-      }
       this.zoomChart();
     }, 0);
   }

--- a/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input } from '@angular/core';
 import { DateRange, MatDatepickerInputEvent, MatDatepickerModule } from '@angular/material/datepicker';
 import { delay } from 'rxjs';
 import { FhirChartConfigurationService } from '../fhir-chart/fhir-chart-configuration.service';
@@ -64,12 +64,14 @@ export class TimelineRangeSelectorComponent {
   }
 
   dateChange(event: MatDatepickerInputEvent<Date>, datePickerType: string) {
-    if (datePickerType === 'min') {
-      this.selectedDateRange = new DateRange(event.value, this.selectedDateRange.end);
-    } else {
-      this.selectedDateRange = new DateRange(this.selectedDateRange.start, event.value);
-    }
-    this.zoomChart();
+    setTimeout(() => {
+      if (datePickerType === 'min') {
+        this.selectedDateRange = new DateRange(event.value, this.selectedDateRange.end);
+      } else {
+        this.selectedDateRange = new DateRange(this.selectedDateRange.start, event.value);
+      }
+      this.zoomChart();
+    }, 0);
   }
 
   openCalendar() {

--- a/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.ts
+++ b/libs/ngx-charts-on-fhir/src/lib/timeline-range-selector/timeline-range-selector.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input } from '@angular/core';
+import { ChangeDetectorRef, Component, Input } from '@angular/core';
 import { DateRange, MatDatepickerInputEvent, MatDatepickerModule } from '@angular/material/datepicker';
 import { delay } from 'rxjs';
 import { FhirChartConfigurationService } from '../fhir-chart/fhir-chart-configuration.service';


### PR DESCRIPTION
## Overview
Refactor the dateChange method to use setTimeout for better timing control


## How it was tested
Tested by launching the showcase app with mock data
Verified by choosing a custom range using the calendar control.

##Screenshot
![Peek 2025-05-14 16-58](https://github.com/user-attachments/assets/28628c7c-26ff-456d-83d2-48c8b151a32c)


## Checklist

- [x] The title contains a short meaningful summary
- [x] I have added a link to this PR in the Jira issue
- [x] I have described how this was tested
- [x] I have included screen shots for changes that affect the user interface
- [ ] I have updated unit tests
- [ ] I have run unit tests locally
- [ ] I have updated documentation (including README)
